### PR TITLE
Fix CORS error for internal .env WHITELIST

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -22,8 +22,6 @@ const ALLOWED_ORIGINS = [
   ...WHITELIST,
 ]
 
-console.log(ALLOWED_ORIGINS)
-
 function getSocketId(socket) {
   return `${socket.remoteAddress}:${socket.remotePort}`
 }


### PR DESCRIPTION
without a `req.headers.origin` present the origin should fallback to any whitelist set in the internal `.env` file

returns this error when not present
```
Invalid value "undefined" for header "Access-Control-Allow-Origin"
```