### PR TITLE
feat: Added backfill script for migrating accounts data

### DIFF
--- a/prisma/custom/update_account_data_structure.sql
+++ b/prisma/custom/update_account_data_structure.sql
@@ -1,0 +1,5 @@
+-- This script is used to update the data structure of the accounts_data table --
+-- It can't be run directly from the prisma client, so it needs to be run manually --
+UPDATE accounts_data
+SET data = jsonb_build_object('code', '', 'answer', COALESCE(data::text, ''))
+WHERE jsonb_typeof(data) = 'string' OR data IS NULL;


### PR DESCRIPTION
This isn't actually a prisma migration as it doesn't change the database schema.  It backfills the data to support the new schema of the data object we are using on the front end to support storing the user code.  Should only be run manually once and the only reason I'm putting it in the repo is in case someone has data locally they want to migrate.