### PR TITLE
Add elliptic library in JS

### DIFF
--- a/src/languages/javascript/package.json
+++ b/src/languages/javascript/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@savingsatoshi/secp256k1js": "^1.0.0",
-    "@savingsatoshi/bech32js": "^1.0.0"
+    "@savingsatoshi/bech32js": "^1.0.0",
+    "elliptic": "^6.5.4"
   }
 }


### PR DESCRIPTION
Allows us to use the elliptic library for testing code in our JS repl