### PR TITLE
Join the payload lines into a single payload

### DIFF
--- a/src/lib/stream.ts
+++ b/src/lib/stream.ts
@@ -23,16 +23,13 @@ class Stream extends Writable {
   }
 
   sendLines(lines) {
-    lines.forEach((line) => {
-      line = this.transformer(line)
-      if (line) {
-        line = line.replace(/\r$/, '')
-        this.send({
-          type: this.channel,
-          payload: line,
-        })
-      }
-    })
+    const joinedLines = lines.map(this.transformer).filter(Boolean).join('\n');
+    if (joinedLines) {
+      this.send({
+        type: this.channel,
+        payload: joinedLines,
+      })
+    }
   }
 
   getError(chunk) {


### PR DESCRIPTION
Since our docker was sending payloads one at a time over the websocket, any delay waas causing the stream to end and the container to close early. This was not a problem locally as all the payloads would come instantly but over the internet this meant that only the first payload of a given return would be shown

This change combines all the payloads into a single object