### PR TITLE
Add user progress script

### DIFF
--- a/bin/README.MD
+++ b/bin/README.MD
@@ -1,0 +1,51 @@
+
+At the time of writing, there is a bug in the system where the `accounts_progress.progress` field is not updated correctly. This directory contains a script to get around the bug and to generate a snapshot of user progress. Here's how to run it:
+
+## Requirements
+This script uses `psql` to read from the database. To check if it is installed, use `psql --version`.
+
+If you do not have it, it's recommended you get it by installing Postgres: `brew install postgresql`. If you prefer to only install the client utilities like `psql` without all of Postgres, run `brew install libpq`.
+
+## Step 1: Run the `user_progress.sh` script
+
+Example:
+
+```
+./user_progress.sh -d YOUR_DB_NAME -u YOUR_DB_USERNAME -h YOUR_DB_HOST -p YOUR_DB_PORT -o ./user_progress_raw.csv
+```
+
+## Step 2: Run this `awk` command to aggregate the results of user_progress_raw.csv into a new file, `user_progress_aggregated.csv`. This will tally up the number of users at each lesson in the game:
+
+```
+awk -F',' 'NR > 1 { counts[$2]++ } END { for (p in counts) print p "," counts[p] }' user_progress_raw.csv \
+| awk -F',' '{ prefix = ($1 ~ /^CH10/) ? "z" : "a"; print prefix "," $0 }' \
+| sort \
+| cut -d',' -f2- \
+| awk 'BEGIN { print "progress,count" } { print }' \
+> user_progress_aggregated.csv
+```
+
+## [OPTIONAL] Step 3: You can further aggregate the results by chapter with this `awk` command that prints to a new file called `user_progress_aggregate_by_chapter.csv`:
+
+```
+awk -F',' '
+NR == 1 { next } # Skip header
+
+{
+  if (match($1, /^CH[0-9]+/)) {
+    chapter = substr($1, RSTART, RLENGTH)
+    counts[chapter] += $2
+  }
+}
+
+END {
+  print "chapter,count"
+  for (i = 1; i <= 10; i++) {
+    chapter = "CH" i
+    if (chapter in counts) {
+      print chapter "," counts[chapter]
+    }
+  }
+}
+' user_progress_aggregated.csv > user_progress_aggregated_by_chapter.csv
+```

--- a/bin/user_progress.sh
+++ b/bin/user_progress.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+# Default config
+TABLE_NAME="accounts_progress"
+ACCOUNT_ID_COLUMN="account"
+PROGRESS_STATE_COLUMN="progress_state"
+CURRENT_LESSON_FIELD="currentLesson"
+
+
+# Usage message
+usage() {
+  echo "This script parses the accounts_progress.progress_state column in the database to create a file with" \
+  "the current progress for each account. You must have psql and jq installed to run it."
+  echo "Usage: $0 -d DB_NAME -u DB_USER -h DB_HOST -p DB_PORT -o OUTPUT_CSV"
+  exit 1
+}
+
+# Parse the command line options
+while getopts ":d:u:h:p:o:" opt; do
+  case $opt in
+    d) DB_NAME="$OPTARG" ;;
+    u) DB_USER="$OPTARG" ;;
+    h) DB_HOST="$OPTARG" ;;
+    p) DB_PORT="$OPTARG" ;;
+    o) OUTPUT_CSV="$OPTARG" ;;
+    *) usage;;
+  esac
+done
+
+if [[ -z "$DB_NAME" || -z "$DB_USER" || -z "$DB_HOST" || -z "$DB_PORT" || -z "$OUTPUT_CSV" ]]; then
+  usage
+fi
+
+# Set up the CSV headers
+ACCOUNT_ID_HEADER_CSV="account_id"
+CURRENT_LESSON_HEADER_CSV="current_lesson"
+echo "${ACCOUNT_ID_HEADER_CSV},${CURRENT_LESSON_HEADER_CSV}" > "${OUTPUT_CSV}"
+
+# Query the db and parse each row
+psql -U "$DB_USER" -h "$DB_HOST" -p "$DB_PORT" -d "$DB_NAME" -t -A -F $'\t' -c \
+"SELECT ${ACCOUNT_ID_COLUMN}, ${PROGRESS_STATE_COLUMN} FROM ${TABLE_NAME} WHERE ${PROGRESS_STATE_COLUMN} IS NOT NULL;" | \
+while IFS=$'\t' read -r account_id account_progress_json; do
+  current_lesson=$(echo "$account_progress_json" | jq -r ".${CURRENT_LESSON_FIELD}")
+  echo "$account_id,$current_lesson" >> "$OUTPUT_CSV"
+done


### PR DESCRIPTION
This PR adds a bash script for obtaining a snapshot of user progress from the database. It's designed to be a stopgap for https://github.com/saving-satoshi/saving-satoshi/issues/1268

The script parses out the `currentLesson` field from the `progress_state` JSON column in the `accounts_progress` table and creates a CSV of the raw data (account ID and current lesson). The `README.md` has two `awk` commands you can use to further aggregate this data: one by lesson, and one by chapter.

I would have automated this further as it's kind of clunky to be creating multiple CSVs but the real fix is to handle the bug that is causing the `accounts_progress.progress` column to be incorrect. The PR for that is: https://github.com/saving-satoshi/saving-satoshi-backend/pull/69