### PR TITLE
Migration for progress table with test

### DIFF
--- a/.github/workflows/check-all-test.yml
+++ b/.github/workflows/check-all-test.yml
@@ -44,9 +44,15 @@ jobs:
     - name: Generate Prisma Client
       run: yarn db:generate
 
+    - name: Run Database Migrations
+      run: yarn db:migrate:production
+      env:
+        DATABASE_URL: ${{ secrets.TEST_DATABASE_URL }}
+
     - name: Run tests with coverage
       run: yarn test
       env:
         NODE_ENV: test
         DATABASE_URL: ${{ secrets.TEST_DATABASE_URL }}
-        WHITELIST: ${{secrets.TEST_WHITELIST}}
+        WHITELIST: ${{ secrets.TEST_WHITELIST }}
+        SECRET: ${{ secrets.TEST_SECRET }}

--- a/prisma/migrations/20251220213221_progress_varchar_length/migration.sql
+++ b/prisma/migrations/20251220213221_progress_varchar_length/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "accounts_progress" ALTER COLUMN "progress" SET DATA TYPE VARCHAR(20);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -19,7 +19,7 @@ model accounts {
 model accounts_progress {
   id            Int       @id @default(autoincrement())
   account       Int       @unique
-  progress      String    @db.VarChar(8)
+  progress      String    @db.VarChar(20)
   progress_state Json?
 
   accounts accounts? @relation(fields: [account], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "accounts_progress_account_id_fkey")

--- a/src/test/routes/progress.test.ts
+++ b/src/test/routes/progress.test.ts
@@ -1,0 +1,127 @@
+import request from 'supertest'
+import { testApp, prisma } from '../setup'
+import jwt from 'jsonwebtoken'
+
+describe('Progress API', () => {
+  let authToken: string
+  let accountId: number
+
+  beforeEach(async () => {
+    const account = await prisma.accounts.create({
+      data: {
+        private_key: 'test_private_123',
+        avatar: 'avatar1',
+      },
+    })
+    accountId = account.id
+    authToken = jwt.sign({ id: accountId, private_key: 'test_private_key_123', avatar: 'avatar1' }, process.env.SECRET || 'test-secret')
+  })
+
+  describe('PUT /api/v1/progress', () => {
+    it('should save progress with short lesson IDs', async () => {
+      const progressState = {
+        currentChapter: 1,
+        currentLesson: 'CH1INT1',
+        chapters: [],
+      }
+
+      const response = await request(testApp)
+        .put('/api/v1/progress')
+        .set('Authorization', `Bearer ${authToken}`)
+        .send({ progress_state: progressState })
+        .expect(200)
+
+      expect(response.body.progress).toBe('CH1INT1')
+      expect(response.body.progress_state).toEqual(progressState)
+    })
+
+    it('should save progress with medium length lesson IDs', async () => {
+      const progressState = {
+        currentChapter: 9,
+        currentLesson: 'CH9OPC10',
+        chapters: [],
+      }
+
+      const response = await request(testApp)
+        .put('/api/v1/progress')
+        .set('Authorization', `Bearer ${authToken}`)
+        .send({ progress_state: progressState })
+        .expect(200)
+
+      expect(response.body.progress).toBe('CH9OPC10')
+      expect(response.body.progress_state).toEqual(progressState)
+    })
+
+    it('should save progress with long lesson IDs (14 characters)', async () => {
+      const progressState = {
+        currentChapter: 6,
+        currentLesson: 'CH6PUT3_NORMAL',
+        chapters: [],
+      }
+
+      const response = await request(testApp)
+        .put('/api/v1/progress')
+        .set('Authorization', `Bearer ${authToken}`)
+        .send({ progress_state: progressState })
+        .expect(200)
+
+      expect(response.body.progress).toBe('CH6PUT3_NORMAL')
+      expect(response.body.progress_state).toEqual(progressState)
+    })
+
+    it('should save progress with long lesson IDs for HARD Chapters', async () => {
+      const progressState = {
+        currentChapter: 6,
+        currentLesson: 'CH6PUT3_HARD',
+        chapters: [],
+      }
+
+      const response = await request(testApp)
+        .put('/api/v1/progress')
+        .set('Authorization', `Bearer ${authToken}`)
+        .send({ progress_state: progressState })
+        .expect(200)
+
+      expect(response.body.progress).toBe('CH6PUT3_HARD')
+      expect(response.body.progress_state).toEqual(progressState)
+    })
+
+    it('should retrieve saved progress correctly with long lesson IDs', async () => {
+      const progressState = {
+        currentChapter: 6,
+        currentLesson: 'CH6PUT3_HARD',
+        chapters: [
+          {
+            id: 6,
+            completed: false,
+            hasDifficulty: true,
+            selectedDifficulty: 'HARD',
+            difficulties: [
+              {
+                level: 'HARD',
+                lessons: [
+                  { id: 'CH6PUT3_HARD', path: '/chapter-6/put-it-together-3-hard', completed: true },
+                ],
+                completed: false,
+              },
+            ],
+          },
+        ],
+      }
+
+      await request(testApp)
+        .put('/api/v1/progress')
+        .set('Authorization', `Bearer ${authToken}`)
+        .send({ progress_state: progressState })
+        .expect(200)
+
+      const getResponse = await request(testApp)
+        .get('/api/v1/progress')
+        .set('Authorization', `Bearer ${authToken}`)
+        .expect(200)
+
+      expect(getResponse.body.progress).toBe('CH6PUT3_HARD')
+      expect(getResponse.body.progress_state.currentLesson).toBe('CH6PUT3_HARD')
+    })
+  })
+})


### PR DESCRIPTION
 This PR fixes a database migration issue where the progress column length was not properly updated in the progress table.

 In migration https://github.com/saving-satoshi/saving-satoshi-backend/blob/8a955200c324a172f3256060b72c295ad76facce/prisma/migrations/20240708140449_update/migration.sql, the maximum length was increased for the account table  but not for the progress table.

 PR #69 uses the progress column, but the migration to support the larger data size was missing for the progress table. This caused issues in hard mode but normal mode continued working.

This Fixes Discord user issue: https://discord.com/channels/903125802726596648/1089879043626778655/1453205302521368737
  It could also be related to: https://github.com/saving-satoshi/saving-satoshi/issues/1342
  
  Edit: we use the normal characters for normal mode