### PR TITLE
fix(repl): handle container AutoRemove race condition

### DIFF
--- a/src/lib/repl.ts
+++ b/src/lib/repl.ts
@@ -99,6 +99,24 @@ export async function run(code: string, language: string, context: any) {
           return
         }
 
+        // When AutoRemove is enabled (HostConfig.AutoRemove: true), Docker
+        // removes the container as soon as it exits. This can cause problems because
+        // internally, docker.run() calls container.wait() to get the exit status, but if
+        // Docker removes the container before wait() completes, it returns a 404 "no such
+        // container" error. This race condition is most apparent under load execution
+        // (e.g. e2e tests running many challenges in parallel) or when the script
+        // finishes quickly and Docker's cleanup outpaces the wait() API call. It is a
+        // timing issue — not a real failure. The container ran to completion and its
+        // output was already streamed to the client via runStream. A genuine
+        // 404 (container never created) cannot reach this callback because
+        // createContainer would have thrown first, before wait() is ever called. Any
+        // script errors are detected via the Stream class which parses stdout/stderr
+        // for error patterns, so it is safe to assume the container ran to completion.
+        if (err?.statusCode === 404) {
+          send({ type: 'end', payload: true, channel: 'runtime' })
+          return resolve()
+        }
+
         let success = true
         if (err) {
           send({

--- a/test/integration/websocket/repl.test.ts
+++ b/test/integration/websocket/repl.test.ts
@@ -249,5 +249,61 @@ describe('WebSocket REPL API', () => {
 
       ws2.close()
     })
+
+    it('should handle many concurrent connections executing code simultaneously', async () => {
+      const CONNECTION_COUNT = 12
+      const connections: TestWebSocket[] = []
+      const program = `
+const secp256k1 = require('@savingsatoshi/secp256k1js')
+const G = secp256k1.G
+function privateKeyToPublicKey(privateKey) {
+  const encodedPrivateKey = BigInt(\`0x\${privateKey}\`)
+  const generatorPoint = G.mul(encodedPrivateKey)
+  return generatorPoint
+}      
+      `;
+
+      // Open multiple websocket connections and consume the 'connected' message.
+      for (let i = 0; i < CONNECTION_COUNT; i++) {
+        const conn = await TestWebSocket.connect(server)
+        const connected = await conn.waitForMessage()
+        expect(connected.type).toBe('connected')
+        connections.push(conn)
+      }
+
+      // Submit code on all connections concurrently.
+      connections.forEach((conn, i) => {
+        const code = Buffer.from(`${program} console.log("Connection ${i}")`).toString('base64')
+        conn.send('repl', { code, language: 'javascript' })
+      })
+
+      // Collect results from all connections in parallel.
+      const allResults = await Promise.all(
+        connections.map((conn) => conn.collectUntilEnd())
+      )
+
+      // Verify each connection received correct output.
+      allResults.forEach((messages, i) => {
+        expect(messages.some((m) =>
+          m.type === 'output' && m.payload.includes(`Connection ${i}`))
+        ).toBe(true)
+
+        // temporary debug logging to show the error msg for failed repl runs
+        if (!messages.some((m) => m.type === 'end' && m.payload === true)) {
+          console.log(
+            `Connection ${i} received error:`,
+            messages.map((m) => JSON.stringify(m.payload)).join(', ')
+          )
+        }
+        expect(messages.some((m) => m.type === 'end' && m.payload === true)).toBe(true)
+
+        // Verify no error messages were received.
+        const errors = messages.filter((m) => m.type === 'error')
+        expect(errors).toHaveLength(0)
+      })
+
+      // Clean up all connections.
+      connections.forEach((conn) => conn.close())
+    }, 60000)
   })
 })


### PR DESCRIPTION
When running many code executions in parallel (e.g. during e2e tests), there's a race condition between Docker's `AutoRemove` cleanup and the `container.wait()` call in `docker.run()`. If Docker removes the container before `wait()` completes, it throws a 404 "no such container" error — even though the container ran successfully and its output was already streamed to the client.

<img width="1405" height="790" alt="image" src="https://github.com/user-attachments/assets/e394b4a4-3baf-428e-9e67-efc4c5816c55" />

## What's happening
  - `HostConfig.AutoRemove: true` tells Docker to delete the container as soon as it exits
  - Internally, `docker.run()` calls `container.wait()` to get the exit status
  - Under load, Docker's cleanup can outpace the `wait()` API call, resulting in a 404
  - This is a timing issue, not a real failure — the script already ran and output was streamed
  - A "real" 404 (container never created) can't reach this code path since `createContainer` would have thrown first

This PR adds a targeted catch for that 404 so it resolves gracefully instead of surfacing as an error.                                                                                                                                                                            

This fix is needed to reliably run the frontend Playwright e2e tests added in [saving-satoshi/saving-satoshi#1461](https://github.com/saving-satoshi/saving-satoshi/pull/1461), which execute many challenges in parallel. Without it, some test runs randomly fail due to the race condition.

