### PR TITLE
Route53 DNS delegation

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,6 +8,9 @@
 #   - AWS_ROLE_ARN_TO_ASSUME: The Role ARN which is the output `assumed_role_arn` from
 #       running the Terraform baseline infrastructure in `terraform/base`.
 #   - AWS_REGION: The region into which to deploy the application.
+#   - AWS_ROUTE53_HOSTED_ZONE_ID: The ID of the hosted zone under which the DNS records for
+#       the application will be managed. This value should be the output `dns_zone_id` from
+#       running the Terraform baseline infrastructure in `terraform/base`.
 #   - HOSTNAME: The hostname of the application (ex. api.savingsatoshi.com).
 #
 # Secrets:
@@ -33,6 +36,8 @@ on:
 env:
   ANSIBLE_WORKING_DIR: ansible
   TERRAFORM_WORKING_DIR: terraform
+  TF_VAR_hosted_zone_id: ${{ vars.AWS_ROUTE53_HOSTED_ZONE_ID }}
+  TF_VAR_hostname: ${{ vars.HOSTNAME }}
   TF_VAR_instance_type: ${{ vars.AWS_EC2_INSTANCE_TYPE }}
 
 jobs:

--- a/ansible/playbook.yaml
+++ b/ansible/playbook.yaml
@@ -57,6 +57,7 @@
     - name: Install APT packages
       ansible.builtin.apt:
         name:
+          - certbot
           - docker-ce
           - docker-ce-cli
           - containerd.io
@@ -68,6 +69,7 @@
           - npm
           - fail2ban
           - collectd
+          - python3-certbot-dns-route53
         state: present
 
     - name: Remove default Nginx site
@@ -75,17 +77,15 @@
         path: /etc/nginx/sites-enabled/default
         state: absent
 
-    #
-    # TODO: Consider checking for DNS resolution or adding record management with the DNS
-    #   provider.
-    #
-
-    - name: Install Certbot
-      community.general.snap:
-        name: certbot
-        classic: true
-
     # Certbot: https://rolflekang.com/using-certbot-with-ansible
+    - name: Generate SSL DH parameters
+      community.crypto.openssl_dhparam:
+        path: /etc/letsencrypt/ssl-dhparams.pem
+        size: 2048
+        mode: '644'
+
+    # Use the DNS-01 challenge via the certbot-dns-route53 plugin so that
+    # certificate issuance does not depend on public DNS propagation.
     - name: Register Certbot
       ansible.builtin.shell: |
         certbot -n register --agree-tos --email {{ cert_email | default('admin@savingsatoshi.com', true) }}
@@ -96,20 +96,20 @@
     - name: Setup cronjob for certificate renewal
       ansible.builtin.cron:
         name: certbot-renewal
-        job: "/snap/bin/certbot -q renew"
+        job: "certbot -q renew"
         minute: "0"
         hour: "0"
 
     - name: Get certificate
-      ansible.builtin.command: "certbot -n --nginx certonly -d {{ hostname }}"
+      ansible.builtin.command: "certbot -n --dns-route53 certonly -d {{ hostname }}"
       args:
         creates: "/etc/letsencrypt/live/{{ hostname }}"
       ignore_errors: true
       register: get_certificate_command_result
 
-    - name: Failure notification to update DNS
+    - name: Failure notification
       ansible.builtin.fail:
-        msg: "LetsEncrypt failed to get the certificate. Please update the DNS record to point to the EIP address and re-run Ansible or the pipeline."
+        msg: "LetsEncrypt DNS-01 challenge failed. Ensure the EC2 instance role has the certbot-dns-route53 IAM policy attached and that the hosted zone ID is correct."
       when: get_certificate_command_result.rc != 0
 
     - name: Create application user

--- a/ansible/requirements.yaml
+++ b/ansible/requirements.yaml
@@ -1,3 +1,5 @@
 ---
+collections:
+  - name: community.crypto
 roles:
   - name: christiangda.amazon_cloudwatch_agent

--- a/ansible/saving-satoshi-backend.nginx.j2
+++ b/ansible/saving-satoshi-backend.nginx.j2
@@ -6,7 +6,17 @@ server {
   listen 443 ssl;
   ssl_certificate /etc/letsencrypt/live/{{ hostname }}/fullchain.pem;
   ssl_certificate_key /etc/letsencrypt/live/{{ hostname }}/privkey.pem;
-  include /etc/letsencrypt/options-ssl-nginx.conf;
+
+  # SSL Options from certbot-nginx:
+  #   https://github.com/certbot/certbot/blob/master/certbot-nginx/certbot_nginx/_internal/tls_configs/options-ssl-nginx.conf
+  ssl_session_cache shared:le_nginx_SSL:10m;
+  ssl_session_timeout 1440m;
+  ssl_session_tickets off;
+  ssl_protocols TLSv1.2 TLSv1.3;
+  ssl_prefer_server_ciphers off;
+  ssl_ciphers "ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384";
+
+  # SSL DH Parameters
   ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
 
   location / {

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -6,6 +6,7 @@ Infrastructure for the Saving Satoshi Backend is hosted with AWS and deployed us
 
 To function via the pipeline, a few boilerplate resources are required in the AWS account, namely:
 - An OIDC provider for GitHub Actions. See the documentation [here](https://docs.github.com/en/actions/how-tos/secure-your-work/security-harden-deployments/oidc-in-aws).
+- A Route53 DNS hosted zone which manages records by [DNS delegation](https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/CreatingNewSubdomain.html).
 - A S3 bucket to hold the Terraform remote state. See the documentation [here](https://developer.hashicorp.com/terraform/language/backend/s3).
 
 To illustrate these resources and simplify things for AWS admins, a "base" Terraform configuration is provided in `terraform/base`. Admins should provision these resources by navigating to that directory on their local machine and running the following with their credentials available:
@@ -21,6 +22,8 @@ terraform plan -var terraform_state_bucket_name=saving-satoshi-production-terraf
 
 terraform apply -var terraform_state_bucket_name=saving-satoshi-production-terraform-state -region=us-west-2
 ```
+
+As well, you can customize the DNS zone name by passing the `dns_zone` variable if you are setting up a development environment.
 
 These values need to be configured into GitHub Actions as variables and secrets. Please see the comment documentation in `.github/workflows/deploy.yml` to complete the setup.
 

--- a/terraform/base/main.tf
+++ b/terraform/base/main.tf
@@ -40,6 +40,18 @@ locals {
   }
 }
 
+variable "dns_zone" {
+  type        = string
+  default     = "api.savingsatoshi.com"
+  description = "The DNS zone for the API managed by AWS Route53"
+}
+
+variable "github_repository_name" {
+  type        = string
+  default     = "saving-satoshi/saving-satoshi-backend"
+  description = "The name of the GitHub repository managing the deployment via OIDC"
+}
+
 variable "region" {
   type        = string
   default     = "us-west-2"
@@ -69,14 +81,27 @@ module "github-oidc-provider" {
   source  = "terraform-module/github-oidc-provider/aws"
   version = "2.2.1"
 
-  repositories = ["saving-satoshi/saving-satoshi-backend"]
+  repositories = [var.github_repository_name]
   role_name    = "${local.namespace}-github-oidc"
 
   # TODO: Define least-privilege access for role policies.
   oidc_role_attach_policies = ["arn:aws:iam::aws:policy/AdministratorAccess"]
 }
 
+# Route53 hosted zone
+resource "aws_route53_zone" "primary" {
+  name = var.dns_zone
+}
+
 # Outputs
+output "dns_name_servers" {
+  value = aws_route53_zone.primary.name_servers
+}
+
+output "dns_zone_id" {
+  value = aws_route53_zone.primary.zone_id
+}
+
 output "assumed_role_arn" {
   value = module.github-oidc-provider.oidc_role
 }

--- a/terraform/ec2.tf
+++ b/terraform/ec2.tf
@@ -100,6 +100,14 @@ resource "aws_eip_association" "app_instance" {
   allocation_id = aws_eip.app.id
 }
 
+resource "aws_route53_record" "api" {
+  name    = var.hostname
+  records = [aws_eip.app.public_ip]
+  ttl     = 300
+  type    = "A"
+  zone_id = var.hosted_zone_id
+}
+
 output "public_dns" {
   value = aws_instance.app.public_dns
 }

--- a/terraform/ec2.tf
+++ b/terraform/ec2.tf
@@ -65,6 +65,40 @@ resource "aws_iam_role_policy_attachment" "cloudwatch_agent" {
   policy_arn = "arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy"
 }
 
+# Grant the instance role the minimum permissions required for the
+# certbot-dns-route53 plugin to complete the ACME DNS-01 challenge.
+# LetsEncrypt only modifies TXT records.
+resource "aws_iam_policy" "certbot_dns_route53" {
+  name        = "${local.namespace}-certbot-dns-route53"
+  description = "Allow Certbot DNS-01 challenge to manage ACME TXT records in Route53"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect   = "Allow"
+        Action   = ["route53:ListHostedZones", "route53:GetChange"]
+        Resource = "*"
+      },
+      {
+        Effect   = "Allow"
+        Action   = ["route53:ChangeResourceRecordSets"]
+        Resource = "arn:aws:route53:::hostedzone/${var.hosted_zone_id}"
+        Condition = {
+          "ForAllValues:StringEquals" = {
+            "route53:ChangeResourceRecordSetsRecordTypes" = ["TXT"]
+          }
+        }
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "certbot_dns_route53" {
+  role       = aws_iam_role.app_instance.name
+  policy_arn = aws_iam_policy.certbot_dns_route53.arn
+}
+
 resource "aws_iam_instance_profile" "app_instance" {
   name = "${local.namespace}-app-instance-profile"
   role = aws_iam_role.app_instance.name
@@ -83,8 +117,7 @@ resource "aws_instance" "app" {
 }
 
 # Add an Elastic IP (EIP) so replacing instances will maintain the
-# same IP address. This reduces the need to maintain DNS records
-# when an instance size is change.
+# same IP address.
 #
 # Create an A record with the DNS provider to point to the EIP.
 resource "aws_eip" "app" {

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -4,6 +4,17 @@ variable "ami" {
   description = "ID of the Amazon Machine Image used to create the instance"
 }
 
+variable "hosted_zone_id" {
+  type        = string
+  description = "The ID of the Route53 hosted zone in which to manage DNS records"
+}
+
+variable "hostname" {
+  type        = string
+  default     = "api.savingsatoshi.com"
+  description = "The hostname at which the application will be reached"
+}
+
 variable "instance_type" {
   type        = string
   default     = "t3.large"


### PR DESCRIPTION
This is a small change to add a Route53 hosted zone to the baseline infrastructure configuration, and pass its ID into the deployment process, where Terraform will write a DNS `A` record into it for the application as part of the infrastructure deployment process. LetsEncrypt has also been changed to use a Route53 DNS-01 challenge instead of Nginx for certificate validation to take advantage of this. It is also now installed via APT package manager instead of a Ubuntu snap.

In order to prepare this deployment:
1. ~Run a `terrform apply` on the baseline infrastructure directory to create the new hosted zone in the AWS account.~
2. ~Add GitHub Actions variables to the repository settings, `AWS_ROUTE53_HOSTED_ZONE_ID` and `HOSTNAME`.~
3. ~Find the current EIP in the AWS console for the `production` app and manually create an `A` record in the new Route53 hosted zone to prepare for DNS delegation.~
4. ~DNS manager must log into Namecheap and look carefully at the existing records for `api.savingsatoshi.com` and see if there are any other records in this "zone" (for example `something.api.savingsatoshi.com` or `something.else.api.savingsatoshi.com`). **If there ARE** -- please let me know in Discord **before** continuing and I'll add them to AWS Route53.~
5. ~DNS manager must add four new `NS` (Nameserver) records to Namecheap for `api.savingsatoshi.com`:~
    - `NS api.savingsatoshi.com ns-1377.awsdns-44.org`
    - `NS api.savingsatoshi.com ns-1820.awsdns-35.co.uk`
    - `NS api.savingsatoshi.com ns-203.awsdns-25.com`
    - `NS api.savingsatoshi.com ns-793.awsdns-35.net`
6. ~Wait and test to make sure DNS is served from AWS name servers.~
7. ~DNS manager can remove the pre-exising `A` record for `api.savingsatoshi.com` from Namecheap, to clean up.~
8. When reviewed and ready to merge, delete the manually-created `A` record in the hosted zone and then merge this PR, allowing the pipeline to re-create it.