### PR TITLE
Artillery performance testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ terraform/.terraform
 terraform/base/.terraform
 terraform/base/*.tfstate
 terraform/base/*.tfstate.backup
+
+# Artillery performance test reports
+src/test/performance/artillery/reports/

--- a/Makefile
+++ b/Makefile
@@ -48,8 +48,6 @@ test-perf-smoke:
 test-perf-load:
 	$(ARTILLERY_CMD) run -e load /scripts/profiles/http-tests.yaml
 
-test-perf-stress:
-	$(ARTILLERY_CMD) run -e stress /scripts/profiles/http-tests.yaml
 
 test-perf-repl:
 	$(ARTILLERY_CMD) run /scripts/profiles/repl-capacity.yaml

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,35 @@ stop-deps:
 reset-deps:
 	make stop-deps & make start-deps
 
+# Artillery Performance Tests
+#
+# Start a performance testing server on 8001 beforehand with:
+#   `yarn test:performance`
+#
+# TODO: After upgrading NodeJS to a more recent version,
+#   consider installing Artillery via NPM and running
+#   via script.
+ARTILLERY_TARGET ?= http://127.0.0.1:8001
+ARTILLERY_WS_TARGET ?= ws://127.0.0.1:8001
 
+ARTILLERY_CMD = docker run --rm \
+	-v $(PWD)/test/performance:/scripts \
+	-e ARTILLERY_TARGET=$(ARTILLERY_TARGET) \
+	-e ARTILLERY_WS_TARGET=$(ARTILLERY_WS_TARGET) \
+	-e REPL_DIST_SHORT \
+	-e REPL_DIST_MEDIUM \
+	-e REPL_DIST_LONG \
+	-e REPL_DIST_TIMEOUT \
+	--network=host artilleryio/artillery:latest
 
+test-perf-smoke:
+	$(ARTILLERY_CMD) run -e smoke /scripts/profiles/http-tests.yaml
 
+test-perf-load:
+	$(ARTILLERY_CMD) run -e load /scripts/profiles/http-tests.yaml
 
+test-perf-stress:
+	$(ARTILLERY_CMD) run -e stress /scripts/profiles/http-tests.yaml
+
+test-perf-repl:
+	$(ARTILLERY_CMD) run /scripts/profiles/repl-capacity.yaml

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "db:migrate:production": "npx prisma migrate deploy",
     "test": "cross-env NODE_ENV=test jest --detectOpenHandles",
     "test:watch": "cross-env NODE_ENV=test jest --watch",
-    "test:coverage": "cross-env NODE_ENV=test jest --coverage"
+    "test:coverage": "cross-env NODE_ENV=test jest --coverage",
+    "test:performance": "cross-env NODE_ENV=test PORT=8001 node dist/index.js"
   },
   "_moduleAliases": {
     "lib": "dist/lib",

--- a/test/performance/README.md
+++ b/test/performance/README.md
@@ -106,7 +106,6 @@ make test-perf-smoke
 
 ### Smoke Test (environment: `smoke`)
 Quick validation suitable for CI pipelines:
-- Health check endpoint
 - Feature flags endpoint
 - Full auth flow (register, login, session, logout)
 - WebSocket REPL smoke test

--- a/test/performance/README.md
+++ b/test/performance/README.md
@@ -126,8 +126,8 @@ Aggressive ramp-up to find system limits:
 - Includes REPL stress scenarios
 
 ### REPL Capacity Test (`repl-capacity.yaml`)
-WebSocket test for REPL container limits on t3.large:
-- Phases: 5 → 8 → 12 → 15 → 20 concurrent connections
+WebSocket test for REPL container limits on t2.small:
+- Phases: 2 → 3 → 4 → 5 → 6 concurrent connections
 - Longer phases to observe CPU credit depletion
 - Tests JavaScript and Python execution
 - Critical for EC2 instance sizing
@@ -145,20 +145,25 @@ If you need to add a new scenario (e.g., testing a new API endpoint), add it to 
 
 ## Capacity Planning Metrics
 
-For t3.large (2 vCPU, 8GB RAM):
+For t2.small (1 vCPU, 2GB RAM):
 
-t3 instances are burstable with a 30% baseline (~0.6 vCPU sustained). Performance
-degrades after CPU credits deplete under sustained load.
+t2 instances are burstable with a 20% baseline (~0.2 vCPU sustained). Performance
+degrades after CPU credits deplete under sustained load. Unlike t3, t2 Unlimited
+mode is off by default and must be opted in (extra cost).
+
+Memory budget: ~1350 MB available after OS and app overhead. At 256 MB per REPL
+container, hard cap is ~5 containers before OOM.
 
 | Metric | Healthy | Warning | Critical |
 |--------|---------|---------|----------|
-| Concurrent REPL (burst) | < 25 | 25-35 | > 35 |
-| Concurrent REPL (sustained) | < 10 | 10-15 | > 15 |
-| Memory usage | < 6.5GB | 6.5-7.5GB | > 7.5GB |
+| Concurrent REPL (burst) | < 4 | 4-5 | > 5 |
+| Concurrent REPL (sustained) | < 2 | 2-3 | > 3 |
+| Memory usage | < 1.5GB | 1.5-1.8GB | > 1.8GB |
 | API p99 latency | < 500ms | 500ms-2s | > 2s |
-| Sustained req/s | < 10 | 10-15 | > 15 |
+| Sustained req/s | < 5 | 5-10 | > 10 |
 | Error rate | < 1% | 1-5% | > 5% |
 
 **Testing considerations:**
 - Run stress tests with depleted credits for worst-case baseline
-- Consider t3 unlimited mode if sustained high load is expected
+- Enable t2 Unlimited mode only if burstable CPU is insufficient and cost is acceptable
+- Memory is a binding constraint alongside CPU; monitor both during REPL tests

--- a/test/performance/README.md
+++ b/test/performance/README.md
@@ -24,7 +24,7 @@ make test-perf-smoke
 
 The test suite uses Artillery's **environments feature** to reduce duplication:
 
-- **`http-tests.yaml`** - Consolidated HTTP API tests with 3 environments (smoke/load/stress)
+- **`http-tests.yaml`** - Consolidated HTTP API tests with 2 environments (smoke/load)
   - All environments share the same scenario definitions
   - Each environment has unique phases and SLA thresholds
   - Reduces duplication by ~45% compared to separate files
@@ -39,8 +39,7 @@ The test suite uses Artillery's **environments feature** to reduce duplication:
 | Profile | Duration | Purpose | Command |
 |---------|----------|---------|---------|
 | **smoke** | ~30s | Quick CI validation | `make test-perf-smoke` |
-| **load** | ~12 min | Sustained traffic baseline | `make test-perf-load` |
-| **stress** | ~15 min | Find breaking points | `make test-perf-stress` |
+| **load** | ~14 min | Sustained traffic baseline | `make test-perf-load` |
 | **repl** | ~12 min | REPL container capacity | `make test-perf-repl` |
 
 ### Running Tests Directly with Docker
@@ -55,11 +54,6 @@ docker run --rm -v $(PWD)/test/performance:/scripts \
 docker run --rm -v $(PWD)/test/performance:/scripts \
   --network=host artilleryio/artillery:latest \
   run -e load /scripts/profiles/http-tests.yaml
-
-# Run stress test
-docker run --rm -v $(PWD)/test/performance:/scripts \
-  --network=host artilleryio/artillery:latest \
-  run -e stress /scripts/profiles/http-tests.yaml
 
 # Run REPL capacity test (no environment needed)
 docker run --rm -v $(PWD)/test/performance:/scripts \
@@ -86,8 +80,8 @@ Control the distribution of REPL execution times to simulate realistic user beha
 | `REPL_DIST_TIMEOUT` | `0.02` | Probability of 31-40s execution (triggers 30s timeout) |
 
 ```bash
-# Run with higher timeout rate for stress testing
-REPL_DIST_TIMEOUT=0.10 REPL_DIST_SHORT=0.62 make test-perf-stress
+# Run with higher timeout rate to simulate heavier workloads
+REPL_DIST_TIMEOUT=0.10 REPL_DIST_SHORT=0.62 make test-perf-load
 
 # Run with no timeouts for quick validation
 REPL_DIST_TIMEOUT=0 make test-perf-smoke
@@ -117,15 +111,8 @@ Sustained traffic to establish performance baselines:
 - Scenarios: anonymous browsing, authenticated sessions, lesson data, features, REPL execution
 - SLAs: p99 < 2s, median < 750ms, error rate < 1%
 
-### Stress Test (environment: `stress`)
-Aggressive ramp-up to find system limits:
-- Ramps from 3 to 60 req/s
-- Relaxed SLAs to allow finding breaking points
-- Watch for: error rate spike, latency degradation
-- Includes REPL stress scenarios
-
 ### REPL Capacity Test (`repl-capacity.yaml`)
-WebSocket test for REPL container limits on t2.small:
+WebSocket test for REPL container limits on t3.small:
 - Phases: 2 → 3 → 4 → 5 → 6 concurrent connections
 - Longer phases to observe CPU credit depletion
 - Tests JavaScript and Python execution
@@ -133,22 +120,22 @@ WebSocket test for REPL container limits on t2.small:
 
 ## Shared Scenarios
 
-All HTTP test environments (smoke/load/stress) share the same scenario definitions from `http-tests.yaml`. This means:
+All HTTP test environments (smoke/load) share the same scenario definitions from `http-tests.yaml`. This means:
 
 - **Add a scenario once, it's available to all profiles** - No need to duplicate across files
 - **Scenario weights are shared** - Cannot customize weights per environment (acceptable trade-off)
 - **Phases and SLAs remain customizable** - Each environment has unique traffic patterns and thresholds
-- **Easier maintenance** - Update auth flow once, not 3 times
+- **Easier maintenance** - Update auth flow once, not twice
 
-If you need to add a new scenario (e.g., testing a new API endpoint), add it to `http-tests.yaml` and it will automatically be available to all three environments.
+If you need to add a new scenario (e.g., testing a new API endpoint), add it to `http-tests.yaml` and it will automatically be available to both environments.
 
 ## Capacity Planning Metrics
 
-For t2.small (1 vCPU, 2GB RAM):
+For t3.small (1 vCPU, 2GB RAM):
 
-t2 instances are burstable with a 20% baseline (~0.2 vCPU sustained). Performance
-degrades after CPU credits deplete under sustained load. Unlike t3, t2 Unlimited
-mode is off by default and must be opted in (extra cost).
+t3 instances are burstable with a 20% baseline (~0.2 vCPU sustained). Performance
+degrades after CPU credits deplete under sustained load. Unlike t2, t3 Unlimited
+mode is on by default and accrues extra cost when credits are exhausted.
 
 Memory budget: ~1350 MB available after OS and app overhead. At 256 MB per REPL
 container, hard cap is ~5 containers before OOM.
@@ -163,6 +150,6 @@ container, hard cap is ~5 containers before OOM.
 | Error rate | < 1% | 1-5% | > 5% |
 
 **Testing considerations:**
-- Run stress tests with depleted credits for worst-case baseline
-- Enable t2 Unlimited mode only if burstable CPU is insufficient and cost is acceptable
+- Run load tests with depleted credits for worst-case baseline
+- Disable t3 Unlimited mode if sustained CPU cost is a concern and bursty degradation is acceptable
 - Memory is a binding constraint alongside CPU; monitor both during REPL tests

--- a/test/performance/README.md
+++ b/test/performance/README.md
@@ -116,11 +116,11 @@ Quick validation suitable for CI pipelines:
 Sustained traffic to establish performance baselines:
 - Phases: warmup → ramp → sustained → peak → cooldown
 - Scenarios: anonymous browsing, authenticated sessions, lesson data, features, REPL execution
-- SLAs: p99 < 2s, median < 500ms, error rate < 1%
+- SLAs: p99 < 2s, median < 750ms, error rate < 1%
 
 ### Stress Test (environment: `stress`)
 Aggressive ramp-up to find system limits:
-- Ramps from 10 to 300 requests/second
+- Ramps from 3 to 60 req/s
 - Relaxed SLAs to allow finding breaking points
 - Watch for: error rate spike, latency degradation
 - Includes REPL stress scenarios

--- a/test/performance/README.md
+++ b/test/performance/README.md
@@ -1,0 +1,164 @@
+# Artillery Performance Tests
+
+Performance test suite for capacity planning and load testing.
+
+## Prerequisites
+
+- Docker installed and running
+- Server running locally on port 8001 using `yarn test:performance` (or configure `ARTILLERY_TARGET`)
+
+It's not a good idea to run the performance tests and the unit tests simultaneously. It can lead to unexpected behavior, especially concerning the REPL containers.
+
+## Quick Start
+
+```bash
+# Start dependencies and server
+make start-deps
+yarn build && yarn test:performance
+
+# Run smoke test (quick validation)
+make test-perf-smoke
+```
+
+## Test Architecture
+
+The test suite uses Artillery's **environments feature** to reduce duplication:
+
+- **`http-tests.yaml`** - Consolidated HTTP API tests with 3 environments (smoke/load/stress)
+  - All environments share the same scenario definitions
+  - Each environment has unique phases and SLA thresholds
+  - Reduces duplication by ~45% compared to separate files
+
+- **`repl-capacity.yaml`** - Separate WebSocket REPL capacity tests
+  - Different protocol (WebSocket vs HTTP)
+  - Different testing purpose (container capacity vs API throughput)
+  - Remains independent from HTTP tests
+
+## Test Profiles
+
+| Profile | Duration | Purpose | Command |
+|---------|----------|---------|---------|
+| **smoke** | ~30s | Quick CI validation | `make test-perf-smoke` |
+| **load** | ~12 min | Sustained traffic baseline | `make test-perf-load` |
+| **stress** | ~15 min | Find breaking points | `make test-perf-stress` |
+| **repl** | ~12 min | REPL container capacity | `make test-perf-repl` |
+
+### Running Tests Directly with Docker
+
+```bash
+# Run smoke test using environment selection
+docker run --rm -v $(PWD)/test/performance:/scripts \
+  --network=host artilleryio/artillery:latest \
+  run -e smoke /scripts/profiles/http-tests.yaml
+
+# Run load test
+docker run --rm -v $(PWD)/test/performance:/scripts \
+  --network=host artilleryio/artillery:latest \
+  run -e load /scripts/profiles/http-tests.yaml
+
+# Run stress test
+docker run --rm -v $(PWD)/test/performance:/scripts \
+  --network=host artilleryio/artillery:latest \
+  run -e stress /scripts/profiles/http-tests.yaml
+
+# Run REPL capacity test (no environment needed)
+docker run --rm -v $(PWD)/test/performance:/scripts \
+  --network=host artilleryio/artillery:latest \
+  run /scripts/profiles/repl-capacity.yaml
+```
+
+## Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `ARTILLERY_TARGET` | `http://localhost:8001` | HTTP API target URL |
+| `ARTILLERY_WS_TARGET` | `ws://localhost:8001` | WebSocket target URL |
+
+### REPL Timing Distribution
+
+Control the distribution of REPL execution times to simulate realistic user behavior:
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `REPL_DIST_SHORT` | `0.70` | Probability of 1-5s execution (typical user code) |
+| `REPL_DIST_MEDIUM` | `0.20` | Probability of 5-15s execution (moderate computation) |
+| `REPL_DIST_LONG` | `0.08` | Probability of 15-29s execution (heavy computation) |
+| `REPL_DIST_TIMEOUT` | `0.02` | Probability of 31-40s execution (triggers 30s timeout) |
+
+```bash
+# Run with higher timeout rate for stress testing
+REPL_DIST_TIMEOUT=0.10 REPL_DIST_SHORT=0.62 make test-perf-stress
+
+# Run with no timeouts for quick validation
+REPL_DIST_TIMEOUT=0 make test-perf-smoke
+```
+
+### Testing Remote Servers
+
+```bash
+# Test staging environment
+ARTILLERY_TARGET=https://api-staging.example.com \
+ARTILLERY_WS_TARGET=wss://api-staging.example.com \
+make test-perf-smoke
+```
+
+## Test Descriptions
+
+### Smoke Test (environment: `smoke`)
+Quick validation suitable for CI pipelines:
+- Health check endpoint
+- Feature flags endpoint
+- Full auth flow (register, login, session, logout)
+- WebSocket REPL smoke test
+- SLAs: p99 < 2s, error rate < 1%
+
+### Load Test (environment: `load`)
+Sustained traffic to establish performance baselines:
+- Phases: warmup → ramp → sustained → peak → cooldown
+- Scenarios: anonymous browsing, authenticated sessions, lesson data, features, REPL execution
+- SLAs: p99 < 2s, median < 500ms, error rate < 1%
+
+### Stress Test (environment: `stress`)
+Aggressive ramp-up to find system limits:
+- Ramps from 10 to 300 requests/second
+- Relaxed SLAs to allow finding breaking points
+- Watch for: error rate spike, latency degradation
+- Includes REPL stress scenarios
+
+### REPL Capacity Test (`repl-capacity.yaml`)
+WebSocket test for REPL container limits on t3.large:
+- Phases: 5 → 8 → 12 → 15 → 20 concurrent connections
+- Longer phases to observe CPU credit depletion
+- Tests JavaScript and Python execution
+- Critical for EC2 instance sizing
+
+## Shared Scenarios
+
+All HTTP test environments (smoke/load/stress) share the same scenario definitions from `http-tests.yaml`. This means:
+
+- **Add a scenario once, it's available to all profiles** - No need to duplicate across files
+- **Scenario weights are shared** - Cannot customize weights per environment (acceptable trade-off)
+- **Phases and SLAs remain customizable** - Each environment has unique traffic patterns and thresholds
+- **Easier maintenance** - Update auth flow once, not 3 times
+
+If you need to add a new scenario (e.g., testing a new API endpoint), add it to `http-tests.yaml` and it will automatically be available to all three environments.
+
+## Capacity Planning Metrics
+
+For t3.large (2 vCPU, 8GB RAM):
+
+t3 instances are burstable with a 30% baseline (~0.6 vCPU sustained). Performance
+degrades after CPU credits deplete under sustained load.
+
+| Metric | Healthy | Warning | Critical |
+|--------|---------|---------|----------|
+| Concurrent REPL (burst) | < 25 | 25-35 | > 35 |
+| Concurrent REPL (sustained) | < 10 | 10-15 | > 15 |
+| Memory usage | < 6.5GB | 6.5-7.5GB | > 7.5GB |
+| API p99 latency | < 500ms | 500ms-2s | > 2s |
+| Sustained req/s | < 10 | 10-15 | > 15 |
+| Error rate | < 1% | 1-5% | > 5% |
+
+**Testing considerations:**
+- Run stress tests with depleted credits for worst-case baseline
+- Consider t3 unlimited mode if sustained high load is expected

--- a/test/performance/processors/functions.js
+++ b/test/performance/processors/functions.js
@@ -68,6 +68,12 @@ const REPL_DIST_MEDIUM = parseFloat(process.env.REPL_DIST_MEDIUM || '0.20');
 const REPL_DIST_LONG = parseFloat(process.env.REPL_DIST_LONG || '0.08');
 const REPL_DIST_TIMEOUT = parseFloat(process.env.REPL_DIST_TIMEOUT || '0.02');
 
+// Values must sum to 1.0; 1e-9 tolerance accounts for floating point rounding errors.
+const _replDistTotal = REPL_DIST_SHORT + REPL_DIST_MEDIUM + REPL_DIST_LONG + REPL_DIST_TIMEOUT;
+if (Math.abs(_replDistTotal - 1.0) > 1e-9) {
+  throw new Error(`REPL_DIST_* values must sum to 1.0, got ${_replDistTotal.toFixed(10)}`);
+}
+
 /**
  * Generate a weighted random delay based on distribution settings.
  * Returns delay in milliseconds.

--- a/test/performance/processors/functions.js
+++ b/test/performance/processors/functions.js
@@ -1,0 +1,124 @@
+const crypto = require('crypto');
+
+/**
+ * Generate a random 64-character hex string for private_key
+ * Used in auth registration and login scenarios
+ * Function signature: (context, ee, next) for flow function steps
+ */
+function generatePrivateKey(context, ee, next) {
+  context.vars.privateKey = crypto.randomBytes(32).toString('hex');
+  return next();
+}
+
+/**
+ * Generate sample progress state for testing
+ */
+function generateProgressState(context, ee, next) {
+  const lessons = ['CH1INT1', 'CH1INT2', 'CH1INT3', 'CH2INT1', 'CH2INT2'];
+  const randomIndex = Math.floor(Math.random() * lessons.length);
+  const randomLesson = lessons[randomIndex];
+
+  context.vars.progressState = {
+    currentChapter: parseInt(randomLesson.charAt(2)),
+    currentLesson: randomLesson,
+    chapters: []
+  };
+  return next();
+}
+
+/**
+ * Generate unique test identifier
+ */
+function generateTestId(context, ee, next) {
+  context.vars.testId = `test_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
+  return next();
+}
+
+/**
+ * Log response for debugging (use sparingly in load tests)
+ * Enable with ARTILLERY_DEBUG=true environment variable
+ * Function signature: (requestParams, response, context, ee, next) for afterResponse hooks
+ */
+function logResponse(requestParams, response, context, ee, next) {
+  if (process.env.ARTILLERY_DEBUG === 'true') {
+    console.log(`[${context.vars.testId || 'unknown'}] Status: ${response.statusCode}`);
+  }
+  return next();
+}
+
+// =============================================================================
+// REPL Code Generation with Configurable Timing Distribution
+// =============================================================================
+//
+// Environment variables to control execution time distribution:
+//   REPL_DIST_SHORT   - Probability of 1-5s execution (default: 0.70)
+//                       Simulates typical user code: hello world, simple scripts
+//   REPL_DIST_MEDIUM  - Probability of 5-15s execution (default: 0.20)
+//                       Simulates moderate computation: loops, data processing
+//   REPL_DIST_LONG    - Probability of 15-29s execution (default: 0.08)
+//                       Simulates heavy computation approaching timeout
+//   REPL_DIST_TIMEOUT - Probability of 31-40s execution (default: 0.02)
+//                       Simulates code that exceeds 30s timeout limit
+//
+// Example: Run with 10% timeout rate for stress testing:
+//   REPL_DIST_TIMEOUT=0.10 REPL_DIST_SHORT=0.62 make test-perf-stress
+//
+const REPL_DIST_SHORT = parseFloat(process.env.REPL_DIST_SHORT || '0.70');
+const REPL_DIST_MEDIUM = parseFloat(process.env.REPL_DIST_MEDIUM || '0.20');
+const REPL_DIST_LONG = parseFloat(process.env.REPL_DIST_LONG || '0.08');
+const REPL_DIST_TIMEOUT = parseFloat(process.env.REPL_DIST_TIMEOUT || '0.02');
+
+/**
+ * Generate a weighted random delay based on distribution settings.
+ * Returns delay in milliseconds.
+ */
+function getWeightedDelay() {
+  const rand = Math.random();
+  const shortThreshold = REPL_DIST_SHORT;
+  const mediumThreshold = shortThreshold + REPL_DIST_MEDIUM;
+  const longThreshold = mediumThreshold + REPL_DIST_LONG;
+
+  if (rand < shortThreshold) {
+    return 1000 + Math.random() * 4000;       // 1-5 seconds
+  } else if (rand < mediumThreshold) {
+    return 5000 + Math.random() * 10000;      // 5-15 seconds
+  } else if (rand < longThreshold) {
+    return 15000 + Math.random() * 14000;     // 15-29 seconds
+  } else {
+    return 31000 + Math.random() * 9000;      // 31-40 seconds (triggers timeout)
+  }
+}
+
+/**
+ * Generate JavaScript REPL code with variable execution time.
+ * Sets context.vars.replCode (base64) and context.vars.replDelay (seconds to wait)
+ */
+function generateJsReplCode(context, ee, next) {
+  const delayMs = Math.floor(getWeightedDelay());
+  const code = `const d=${delayMs},s=Date.now();while(Date.now()-s<d){}console.log('Done:'+d+'ms');`;
+  context.vars.replCode = Buffer.from(code).toString('base64');
+  context.vars.replDelay = Math.ceil(delayMs / 1000) + 2; // execution time + buffer
+  return next();
+}
+
+/**
+ * Generate Python REPL code with variable execution time.
+ * Sets context.vars.replCode (base64) and context.vars.replDelay (seconds to wait)
+ */
+function generatePyReplCode(context, ee, next) {
+  const delayMs = Math.floor(getWeightedDelay());
+  const delaySec = (delayMs / 1000).toFixed(2);
+  const code = `import time;d=${delaySec};s=time.time()\nwhile time.time()-s<d:pass\nprint(f'Done:{d}s')`;
+  context.vars.replCode = Buffer.from(code).toString('base64');
+  context.vars.replDelay = Math.ceil(delayMs / 1000) + 2; // execution time + buffer
+  return next();
+}
+
+module.exports = {
+  generatePrivateKey,
+  generateProgressState,
+  generateTestId,
+  logResponse,
+  generateJsReplCode,
+  generatePyReplCode
+};

--- a/test/performance/processors/functions.js
+++ b/test/performance/processors/functions.js
@@ -91,25 +91,55 @@ function getWeightedDelay() {
 
 /**
  * Generate JavaScript REPL code with variable execution time.
+ * Runs secp256k1 point multiplications (G.mul) for the target duration, mirroring
+ * the actual CPU work saving-satoshi users perform in production.
  * Sets context.vars.replCode (base64) and context.vars.replDelay (seconds to wait)
  */
 function generateJsReplCode(context, ee, next) {
   const delayMs = Math.floor(getWeightedDelay());
-  const code = `const d=${delayMs},s=Date.now();while(Date.now()-s<d){}console.log('Done:'+d+'ms');`;
-  context.vars.replCode = Buffer.from(code).toString('base64');
+  const privateKey = crypto.randomBytes(32).toString('hex');
+  const lines = [
+    `const {G} = require('@savingsatoshi/secp256k1js');`,
+    `const key = BigInt('0x${privateKey}');`,
+    `const start = Date.now();`,
+    `const target = ${delayMs};`,
+    `let i = 0n;`,
+    `while (Date.now() - start < target) { G.mul(key + i++); }`,
+    `console.log('Done: ' + i + ' ops in ' + (Date.now() - start) + 'ms');`,
+  ];
+  context.vars.replCode = Buffer.from(lines.join('\n')).toString('base64');
   context.vars.replDelay = Math.ceil(delayMs / 1000) + 2; // execution time + buffer
   return next();
 }
 
 /**
  * Generate Python REPL code with variable execution time.
+ * Runs secp256k1 point multiplications (scalar * G) for the target duration, mirroring
+ * the actual CPU work saving-satoshi users perform in production.
  * Sets context.vars.replCode (base64) and context.vars.replDelay (seconds to wait)
+ *
+ * Import note: the package installs as 'savingsatoshi-secp256k1py' but the Python
+ * module namespace is 'secp256k1py', so the import is 'from secp256k1py.secp256k1 import G'.
+ * Scalar multiplication uses the __rmul__ operator: (key + i) * G
  */
 function generatePyReplCode(context, ee, next) {
   const delayMs = Math.floor(getWeightedDelay());
   const delaySec = (delayMs / 1000).toFixed(2);
-  const code = `import time;d=${delaySec};s=time.time()\nwhile time.time()-s<d:pass\nprint(f'Done:{d}s')`;
-  context.vars.replCode = Buffer.from(code).toString('base64');
+  // Generate key as a decimal integer for Python (no BigInt literal syntax)
+  const keyInt = BigInt('0x' + crypto.randomBytes(32).toString('hex')).toString();
+  const lines = [
+    'from secp256k1py.secp256k1 import G',
+    'import time',
+    `key = ${keyInt}`,
+    'start = time.time()',
+    `target = ${delaySec}`,
+    'i = 0',
+    'while time.time() - start < target:',
+    '    (key + i) * G',
+    '    i += 1',
+    "print(f'Done: {i} ops in {time.time() - start:.2f}s')",
+  ];
+  context.vars.replCode = Buffer.from(lines.join('\n')).toString('base64');
   context.vars.replDelay = Math.ceil(delayMs / 1000) + 2; // execution time + buffer
   return next();
 }

--- a/test/performance/processors/functions.js
+++ b/test/performance/processors/functions.js
@@ -60,8 +60,8 @@ function logResponse(requestParams, response, context, ee, next) {
 //   REPL_DIST_TIMEOUT - Probability of 31-40s execution (default: 0.02)
 //                       Simulates code that exceeds 30s timeout limit
 //
-// Example: Run with 10% timeout rate for stress testing:
-//   REPL_DIST_TIMEOUT=0.10 REPL_DIST_SHORT=0.62 make test-perf-stress
+// Example: Run with 10% timeout rate to simulate heavier workloads:
+//   REPL_DIST_TIMEOUT=0.10 REPL_DIST_SHORT=0.62 make test-perf-load
 //
 const REPL_DIST_SHORT = parseFloat(process.env.REPL_DIST_SHORT || '0.70');
 const REPL_DIST_MEDIUM = parseFloat(process.env.REPL_DIST_MEDIUM || '0.20');

--- a/test/performance/profiles/http-tests.yaml
+++ b/test/performance/profiles/http-tests.yaml
@@ -2,20 +2,18 @@
 # CONSOLIDATED HTTP API TESTS
 # =============================================================================
 # This file contains all HTTP-based performance test profiles using Artillery's
-# environments feature. Each environment (smoke/load/stress) has its own phases
+# environments feature. Each environment (smoke/load) has its own phases
 # and SLAs, but shares the same scenario definitions.
 #
 # Usage:
 #   artillery run -e smoke /scripts/profiles/http-tests.yaml
 #   artillery run -e load /scripts/profiles/http-tests.yaml
-#   artillery run -e stress /scripts/profiles/http-tests.yaml
 #
 # Or via Makefile:
 #   make test-perf-smoke
 #   make test-perf-load
-#   make test-perf-stress
 #
-# IMPORTANT: All 8 scenarios run in ALL environments (smoke/load/stress).
+# IMPORTANT: All 8 scenarios run in ALL environments (smoke/load).
 # Environments differ ONLY in their phases (duration/traffic) and SLAs.
 # Scenario weights, think times, and request flows are identical across
 # all environments. This is a fundamental limitation of Artillery's
@@ -43,7 +41,7 @@ config:
   # Use when: CI pipelines, pre-deployment checks, quick health validation
   #
   # What it tests:
-  #   - All 8 API scenarios run with light traffic (2-5 req/s)
+  #   - All 7 API scenarios run with light traffic (2-5 req/s)
   #   - Validates that endpoints are reachable and respond correctly
   #   - Quick health check suitable for CI/CD pipelines
   #   - Expected behavior: All requests succeed, fast response times
@@ -52,9 +50,9 @@ config:
   #   - p99 response time < 2 seconds
   #   - Error rate < 1%
   #
-  # Differences from other profiles:
-  #   - Shortest duration (30s vs 12-15 min for load/stress)
-  #   - Lowest traffic (2-5 req/s vs up to 60 req/s for stress)
+  # Differences from load profile:
+  #   - Shortest duration (30s vs ~12 min for load)
+  #   - Lowest traffic (2-5 req/s vs up to 12 req/s for load)
   #   - Strictest SLAs (designed to pass reliably)
   # ==========================================================================
   environments:
@@ -137,93 +135,11 @@ config:
         # Errors under sustained load indicate capacity or stability issues
         maxErrorRate: 1
 
-    # ========================================================================
-    # ENVIRONMENT: STRESS TEST
-    # ========================================================================
-    # Purpose: Push the system beyond normal limits to find maximum capacity
-    # Duration: ~15 minutes
-    # Use when: Capacity planning, identifying bottlenecks, testing autoscaling triggers
-    #
-    # What it tests:
-    #   - All 8 API scenarios run with extreme traffic (3-60 req/s)
-    #   - Pushes system beyond normal capacity to find breaking points
-    #   - Identifies at what load level errors begin and latency degrades
-    #   - Tests resource exhaustion: DB connections, memory, CPU limits
-    #   - Expected behavior: Graceful degradation, some errors acceptable
-    #
-    # Traffic pattern (aggressive ramp-up):
-    #   - Baseline:     60s at 3 req/s
-    #   - Moderate:     120s ramp to 15 req/s, hold 120s
-    #   - High:         120s ramp to 25 req/s, hold 120s
-    #   - Extreme:      120s ramp to 40 req/s, hold 120s
-    #   - Beyond:       60s ramp to 60 req/s
-    #
-    # SLAs (intentionally relaxed - we expect failures):
-    #   - p99 response time < 10 seconds
-    #   - Error rate < 10%
-    #
-    # Differences from other profiles:
-    #   - Longest duration (15 min) with aggressive ramp-up pattern
-    #   - Highest traffic volume (3-60 req/s)
-    #   - Relaxed SLAs (p99 < 10s, maxErrorRate < 10%) to allow finding limits
-    #   - Purpose is to identify breaking points, not validate normal operation
-    #
-    # Key metrics to watch:
-    #   - Point where error rate spikes (system saturation)
-    #   - Point where latency degrades significantly
-    #   - Memory/CPU usage on the server during test
-    #
-    # t2.small notes:
-    #   - 1 vCPU with 20% baseline (~0.2 vCPU sustained)
-    #   - CPU credits: 12/hour (accumulate up to 288); no Unlimited mode by default
-    #   - With credits: expect breaking at ~30-40 req/s
-    #   - After depletion: expect breaking at ~15-25 req/s
-    #   - For sustained baseline testing, run after credits are depleted
-    # ========================================================================
-    stress:
-      phases:
-        - name: "Baseline"
-          duration: 60
-          arrivalRate: 3
-        - name: "Ramp to moderate"
-          duration: 120
-          arrivalRate: 3
-          rampTo: 15
-        - name: "Hold moderate"
-          duration: 120
-          arrivalRate: 15
-        - name: "Ramp to high"
-          duration: 120
-          arrivalRate: 15
-          rampTo: 25
-        - name: "Hold high"
-          duration: 120
-          arrivalRate: 25
-        - name: "Ramp to extreme"
-          duration: 120
-          arrivalRate: 25
-          rampTo: 40
-        - name: "Hold extreme"
-          duration: 120
-          arrivalRate: 40
-        - name: "Beyond capacity"
-          duration: 60
-          arrivalRate: 40
-          rampTo: 60
-
-      ensure:
-        # p99 < 10s: Allow high latency since we're pushing past normal limits
-        # We expect degradation; this just prevents complete system lockup
-        p99: 10000
-        # maxErrorRate < 10%: Allow up to 10% errors under extreme load
-        # The goal is to find WHERE errors start, not to have zero errors
-        # Watch the metrics to identify the breaking point
-        maxErrorRate: 10
 
 # =============================================================================
 # SHARED SCENARIOS
 # =============================================================================
-# All scenarios below are shared across smoke/load/stress environments.
+# All scenarios below are shared across smoke/load environments.
 # Artillery's environments feature means ALL scenarios run in ALL environments,
 # with different phases and SLAs per environment controlling the test behavior.
 #
@@ -232,10 +148,6 @@ config:
 # - Think times simulate human pacing between actions (1–3s for HTTP, 1s + replDelay for REPL)
 # - No continueOnError flags - tests fail fast for clearer debugging
 # - Traffic differentiation comes from environment-specific phases and SLAs
-#
-# Note: This is a limitation of Artillery's environments - we cannot selectively
-# run different scenarios per environment. However, the different phases (30s
-# for smoke vs 15min for stress) and SLAs naturally differentiate test behavior.
 # =============================================================================
 
 scenarios:

--- a/test/performance/profiles/http-tests.yaml
+++ b/test/performance/profiles/http-tests.yaml
@@ -23,7 +23,7 @@
 # =============================================================================
 
 config:
-  target: "http://localhost:8001"
+  target: "{{ $processEnvironment.ARTILLERY_TARGET }}"
 
   plugins:
     expect: {}
@@ -443,7 +443,7 @@ scenarios:
     engine: ws
     flow:
       - function: "generateJsReplCode"
-      - connect: "ws://localhost:8001"
+      - connect: "{{ $processEnvironment.ARTILLERY_WS_TARGET }}"
       - think: 1
       # Dynamic JS code with variable execution time (1-40s, see processors/functions.js)
       - send:
@@ -458,7 +458,7 @@ scenarios:
     engine: ws
     flow:
       - function: "generatePyReplCode"
-      - connect: "ws://localhost:8001"
+      - connect: "{{ $processEnvironment.ARTILLERY_WS_TARGET }}"
       - think: 1
       # Dynamic Python code with variable execution time (1-40s, see processors/functions.js)
       - send:

--- a/test/performance/profiles/http-tests.yaml
+++ b/test/performance/profiles/http-tests.yaml
@@ -1,0 +1,466 @@
+# =============================================================================
+# CONSOLIDATED HTTP API TESTS
+# =============================================================================
+# This file contains all HTTP-based performance test profiles using Artillery's
+# environments feature. Each environment (smoke/load/stress) has its own phases
+# and SLAs, but shares the same scenario definitions.
+#
+# Usage:
+#   artillery run -e smoke /scripts/profiles/http-tests.yaml
+#   artillery run -e load /scripts/profiles/http-tests.yaml
+#   artillery run -e stress /scripts/profiles/http-tests.yaml
+#
+# Or via Makefile:
+#   make test-perf-smoke
+#   make test-perf-load
+#   make test-perf-stress
+#
+# IMPORTANT: All 9 scenarios run in ALL environments (smoke/load/stress).
+# Environments differ ONLY in their phases (duration/traffic) and SLAs.
+# Scenario weights, think times, and request flows are identical across
+# all environments. This is a fundamental limitation of Artillery's
+# environments feature - scenarios cannot be selectively enabled per environment.
+# =============================================================================
+
+config:
+  target: "http://localhost:8001"
+
+  plugins:
+    expect: {}
+    metrics-by-endpoint: {}
+
+  processor: "/scripts/processors/functions.js"
+
+  defaults:
+    headers:
+      Content-Type: "application/json"
+
+  # ==========================================================================
+  # ENVIRONMENT: SMOKE TEST
+  # ==========================================================================
+  # Purpose: Fast sanity check that all endpoints are reachable and functional
+  # Duration: ~30 seconds
+  # Use when: CI pipelines, pre-deployment checks, quick health validation
+  #
+  # What it tests:
+  #   - All 9 API scenarios run with light traffic (2-5 req/s)
+  #   - Validates that endpoints are reachable and respond correctly
+  #   - Quick health check suitable for CI/CD pipelines
+  #   - Expected behavior: All requests succeed, fast response times
+  #
+  # SLAs:
+  #   - p99 response time < 2 seconds
+  #   - Error rate < 1%
+  #
+  # Differences from other profiles:
+  #   - Shortest duration (30s vs 12-15 min for load/stress)
+  #   - Lowest traffic (2-5 req/s vs up to 300 req/s for stress)
+  #   - Strictest SLAs (designed to pass reliably)
+  # ==========================================================================
+  environments:
+    smoke:
+      phases:
+        - name: "Smoke test"
+          duration: 30
+          arrivalRate: 2
+          rampTo: 5
+
+      ensure:
+        # p99 < 2s: 99th percentile response time must be under 2 seconds
+        # Chosen as a generous upper bound for a healthy system under light load
+        p99: 2000
+        # maxErrorRate < 1%: Less than 1% of requests can fail
+        # Smoke tests should have near-zero errors; any failures indicate a problem
+        maxErrorRate: 1
+
+    # ========================================================================
+    # ENVIRONMENT: LOAD TEST
+    # ========================================================================
+    # Purpose: Measure system performance under expected production-like traffic
+    # Duration: ~12 minutes
+    # Use when: Establishing performance baselines, capacity planning, regression testing
+    #
+    # What it tests:
+    #   - All 9 API scenarios run with production-like traffic (5-30 req/s)
+    #   - Sustained load over 12 minutes to establish performance baselines
+    #   - Tests system stability under realistic user patterns
+    #   - Expected behavior: Maintains low latency (p99 < 2s, median < 500ms)
+    #
+    # Traffic pattern:
+    #   - Warm up:      60s at 5 req/s
+    #   - Ramp up:      120s from 5 to 20 req/s
+    #   - Sustained:    300s at 20 req/s
+    #   - Peak:         180s at 30 req/s
+    #   - Cool down:    60s from 30 to 5 req/s
+    #
+    # SLAs:
+    #   - p99 response time < 2 seconds
+    #   - Median response time < 500ms
+    #   - Error rate < 1%
+    #
+    # Differences from other profiles:
+    #   - Medium duration (12 min vs 30s for smoke, 15 min for stress)
+    #   - Production-like traffic (5-30 req/s steady)
+    #   - Includes median latency SLA (< 500ms) for user experience validation
+    #   - Multi-phase pattern: warm up → ramp → sustained → peak → cool down
+    # ========================================================================
+    load:
+      phases:
+        - name: "Warm up"
+          duration: 60
+          arrivalRate: 5
+        - name: "Ramp up"
+          duration: 120
+          arrivalRate: 5
+          rampTo: 20
+        - name: "Sustained load"
+          duration: 300
+          arrivalRate: 20
+        - name: "Peak load"
+          duration: 180
+          arrivalRate: 30
+        - name: "Cool down"
+          duration: 60
+          arrivalRate: 30
+          rampTo: 5
+
+      ensure:
+        # p99 < 2s: 99th percentile must stay under 2 seconds even at peak load
+        # This ensures outliers don't degrade user experience significantly
+        p99: 2000
+        # median < 500ms: Typical response should feel snappy to users
+        # Half of all requests must complete within half a second
+        median: 500
+        # maxErrorRate < 1%: Production-like load should not cause errors
+        # Errors under sustained load indicate capacity or stability issues
+        maxErrorRate: 1
+
+    # ========================================================================
+    # ENVIRONMENT: STRESS TEST
+    # ========================================================================
+    # Purpose: Push the system beyond normal limits to find maximum capacity
+    # Duration: ~15 minutes
+    # Use when: Capacity planning, identifying bottlenecks, testing autoscaling triggers
+    #
+    # What it tests:
+    #   - All 9 API scenarios run with extreme traffic (10-300 req/s)
+    #   - Pushes system beyond normal capacity to find breaking points
+    #   - Identifies at what load level errors begin and latency degrades
+    #   - Tests resource exhaustion: DB connections, memory, CPU limits
+    #   - Expected behavior: Graceful degradation, some errors acceptable
+    #
+    # Traffic pattern (aggressive ramp-up):
+    #   - Baseline:     60s at 10 req/s
+    #   - Moderate:     120s ramp to 50 req/s, hold 120s
+    #   - High:         120s ramp to 100 req/s, hold 120s
+    #   - Extreme:      120s ramp to 200 req/s, hold 120s
+    #   - Beyond:       60s ramp to 300 req/s
+    #
+    # SLAs (intentionally relaxed - we expect failures):
+    #   - p99 response time < 10 seconds
+    #   - Error rate < 10%
+    #
+    # Differences from other profiles:
+    #   - Longest duration (15 min) with aggressive ramp-up pattern
+    #   - Highest traffic volume (10-300 req/s)
+    #   - Relaxed SLAs (p99 < 10s, maxErrorRate < 10%) to allow finding limits
+    #   - Purpose is to identify breaking points, not validate normal operation
+    #
+    # Key metrics to watch:
+    #   - Point where error rate spikes (system saturation)
+    #   - Point where latency degrades significantly
+    #   - Memory/CPU usage on the server during test
+    #
+    # t3.large notes:
+    #   - Results depend on CPU credit balance
+    #   - With credits: expect breaking at 200+ req/s
+    #   - After depletion: expect breaking at ~50-100 req/s
+    #   - For sustained baseline testing, run after credits are depleted
+    # ========================================================================
+    stress:
+      phases:
+        - name: "Baseline"
+          duration: 60
+          arrivalRate: 10
+        - name: "Ramp to moderate"
+          duration: 120
+          arrivalRate: 10
+          rampTo: 50
+        - name: "Hold moderate"
+          duration: 120
+          arrivalRate: 50
+        - name: "Ramp to high"
+          duration: 120
+          arrivalRate: 50
+          rampTo: 100
+        - name: "Hold high"
+          duration: 120
+          arrivalRate: 100
+        - name: "Ramp to extreme"
+          duration: 120
+          arrivalRate: 100
+          rampTo: 200
+        - name: "Hold extreme"
+          duration: 120
+          arrivalRate: 200
+        - name: "Beyond capacity"
+          duration: 60
+          arrivalRate: 200
+          rampTo: 300
+
+      ensure:
+        # p99 < 10s: Allow high latency since we're pushing past normal limits
+        # We expect degradation; this just prevents complete system lockup
+        p99: 10000
+        # maxErrorRate < 10%: Allow up to 10% errors under extreme load
+        # The goal is to find WHERE errors start, not to have zero errors
+        # Watch the metrics to identify the breaking point
+        maxErrorRate: 10
+
+# =============================================================================
+# SHARED SCENARIOS
+# =============================================================================
+# All scenarios below are shared across smoke/load/stress environments.
+# Artillery's environments feature means ALL scenarios run in ALL environments,
+# with different phases and SLAs per environment controlling the test behavior.
+#
+# Scenario design:
+# - All scenarios include expect blocks for response validation
+# - REPL scenarios use think time of 1 second
+# - No continueOnError flags - tests fail fast for clearer debugging
+# - Traffic differentiation comes from environment-specific phases and SLAs
+#
+# Note: This is a limitation of Artillery's environments - we cannot selectively
+# run different scenarios per environment. However, the different phases (30s
+# for smoke vs 15min for stress) and SLAs naturally differentiate test behavior.
+# =============================================================================
+
+scenarios:
+  # ===========================================================================
+  # BASIC API SCENARIOS
+  # ===========================================================================
+
+  - name: "Health check"
+    weight: 4
+    flow:
+      - get:
+          url: "/v1/status"
+          expect:
+            - statusCode: 200
+            - hasProperty: "status"
+
+  - name: "List features"
+    weight: 1
+    flow:
+      - get:
+          url: "/v1/features"
+          expect:
+            - statusCode: 200
+
+  # ===========================================================================
+  # AUTHENTICATION SCENARIOS
+  # ===========================================================================
+
+  - name: "Auth flow"
+    weight: 2
+    flow:
+      - function: "generatePrivateKey"
+      - post:
+          url: "/v1/auth/register"
+          json:
+            private_key: "{{ privateKey }}"
+          capture:
+            - json: "$.id"
+              as: "accountId"
+          expect:
+            - statusCode: 200
+            - hasProperty: "id"
+      - post:
+          url: "/v1/auth/login"
+          json:
+            private_key: "{{ privateKey }}"
+          capture:
+            - json: "$.token"
+              as: "authToken"
+          expect:
+            - statusCode: 200
+            - hasProperty: "token"
+      - get:
+          url: "/v1/auth/session"
+          headers:
+            Authorization: "Bearer {{ authToken }}"
+          expect:
+            - statusCode: 200
+      - get:
+          url: "/v1/progress"
+          headers:
+            Authorization: "Bearer {{ authToken }}"
+          expect:
+            - statusCode: 200
+            - hasProperty: "account"
+            - hasProperty: "progress"
+            - hasProperty: "progress_state"
+      - post:
+          url: "/v1/auth/logout"
+          headers:
+            Authorization: "Bearer {{ authToken }}"
+          expect:
+            - statusCode: 200
+
+  # ===========================================================================
+  # USER SESSION SCENARIOS
+  # ===========================================================================
+
+  - name: "Anonymous browsing"
+    weight: 3
+    flow:
+      - get:
+          url: "/v1/status"
+          expect:
+            - statusCode: 200
+      - think: 1
+      - get:
+          url: "/v1/features"
+          expect:
+            - statusCode: 200
+
+  - name: "Authenticated user session"
+    weight: 3
+    flow:
+      - function: "generatePrivateKey"
+      - post:
+          url: "/v1/auth/register"
+          json:
+            private_key: "{{ privateKey }}"
+          capture:
+            - json: "$.id"
+              as: "accountId"
+          expect:
+            - statusCode: 200
+      - post:
+          url: "/v1/auth/login"
+          json:
+            private_key: "{{ privateKey }}"
+          capture:
+            - json: "$.token"
+              as: "authToken"
+          expect:
+            - statusCode: 200
+      - think: 2
+      - function: "generateProgressState"
+      - get:
+          url: "/v1/progress"
+          headers:
+            Authorization: "Bearer {{ authToken }}"
+          expect:
+            - statusCode: 200
+      - think: 3
+      - put:
+          url: "/v1/progress"
+          headers:
+            Authorization: "Bearer {{ authToken }}"
+          json:
+            progress_state: "{{ progressState }}"
+          expect:
+            - statusCode: 200
+      - think: 2
+      - get:
+          url: "/v1/accounts/{{ accountId }}"
+          headers:
+            Authorization: "Bearer {{ authToken }}"
+          expect:
+            - statusCode: 200
+      - post:
+          url: "/v1/auth/logout"
+          headers:
+            Authorization: "Bearer {{ authToken }}"
+
+  # ===========================================================================
+  # DATA OPERATION SCENARIOS
+  # ===========================================================================
+
+  - name: "Lesson data flow"
+    weight: 2
+    flow:
+      - function: "generatePrivateKey"
+      - post:
+          url: "/v1/auth/register"
+          json:
+            private_key: "{{ privateKey }}"
+          capture:
+            - json: "$.id"
+              as: "accountId"
+      - post:
+          url: "/v1/auth/login"
+          json:
+            private_key: "{{ privateKey }}"
+          capture:
+            - json: "$.token"
+              as: "authToken"
+      - think: 1
+      - put:
+          url: "/v1/data"
+          headers:
+            Authorization: "Bearer {{ authToken }}"
+          json:
+            lesson_id: "CH1INT1"
+            data:
+              code: "console.log('hello')"
+              timestamp: "{{ $timestamp }}"
+          expect:
+            - statusCode: 200
+      - think: 2
+      - get:
+          url: "/v1/data/CH1INT1"
+          headers:
+            Authorization: "Bearer {{ authToken }}"
+          expect:
+            - statusCode: 200
+
+  - name: "Feature updates"
+    weight: 1
+    flow:
+      - function: "generateTestId"
+      - put:
+          url: "/v1/features"
+          json:
+            feature_name: "{{ testId }}"
+            feature_value: 1
+          expect:
+            - statusCode: 200
+
+  # ===========================================================================
+  # WEBSOCKET REPL SCENARIOS
+  # ===========================================================================
+  # Note: WebSocket scenarios require separate engine declaration.
+  # ===========================================================================
+
+  - name: "REPL JavaScript execution"
+    weight: 2
+    engine: ws
+    flow:
+      - function: "generateJsReplCode"
+      - connect: "ws://localhost:8001"
+      - think: 1
+      # Dynamic JS code with variable execution time (1-40s, see processors/functions.js)
+      - send:
+          action: "repl"
+          payload:
+            code: "{{ replCode }}"
+            language: "javascript"
+      - think: "{{ replDelay }}"
+
+  - name: "REPL Python execution"
+    weight: 1
+    engine: ws
+    flow:
+      - function: "generatePyReplCode"
+      - connect: "ws://localhost:8001"
+      - think: 1
+      # Dynamic Python code with variable execution time (1-40s, see processors/functions.js)
+      - send:
+          action: "repl"
+          payload:
+            code: "{{ replCode }}"
+            language: "python"
+      - think: "{{ replDelay }}"

--- a/test/performance/profiles/http-tests.yaml
+++ b/test/performance/profiles/http-tests.yaml
@@ -15,7 +15,7 @@
 #   make test-perf-load
 #   make test-perf-stress
 #
-# IMPORTANT: All 9 scenarios run in ALL environments (smoke/load/stress).
+# IMPORTANT: All 8 scenarios run in ALL environments (smoke/load/stress).
 # Environments differ ONLY in their phases (duration/traffic) and SLAs.
 # Scenario weights, think times, and request flows are identical across
 # all environments. This is a fundamental limitation of Artillery's
@@ -43,7 +43,7 @@ config:
   # Use when: CI pipelines, pre-deployment checks, quick health validation
   #
   # What it tests:
-  #   - All 9 API scenarios run with light traffic (2-5 req/s)
+  #   - All 8 API scenarios run with light traffic (2-5 req/s)
   #   - Validates that endpoints are reachable and respond correctly
   #   - Quick health check suitable for CI/CD pipelines
   #   - Expected behavior: All requests succeed, fast response times
@@ -81,7 +81,7 @@ config:
     # Use when: Establishing performance baselines, capacity planning, regression testing
     #
     # What it tests:
-    #   - All 9 API scenarios run with production-like traffic (2-12 req/s)
+    #   - All 8 API scenarios run with production-like traffic (2-12 req/s)
     #   - Sustained load over 12 minutes to establish performance baselines
     #   - Tests system stability under realistic user patterns
     #   - Expected behavior: Maintains low latency (p99 < 2s, median < 750ms)
@@ -145,7 +145,7 @@ config:
     # Use when: Capacity planning, identifying bottlenecks, testing autoscaling triggers
     #
     # What it tests:
-    #   - All 9 API scenarios run with extreme traffic (3-60 req/s)
+    #   - All 8 API scenarios run with extreme traffic (3-60 req/s)
     #   - Pushes system beyond normal capacity to find breaking points
     #   - Identifies at what load level errors begin and latency degrades
     #   - Tests resource exhaustion: DB connections, memory, CPU limits
@@ -243,15 +243,6 @@ scenarios:
   # BASIC API SCENARIOS
   # ===========================================================================
 
-  - name: "Health check"
-    weight: 4
-    flow:
-      - get:
-          url: "/v1/status"
-          expect:
-            - statusCode: 200
-            - hasProperty: "status"
-
   - name: "List features"
     weight: 1
     flow:
@@ -318,7 +309,7 @@ scenarios:
     weight: 3
     flow:
       - get:
-          url: "/v1/status"
+          url: "/v1/features"
           expect:
             - statusCode: 200
       - think: 1

--- a/test/performance/profiles/http-tests.yaml
+++ b/test/performance/profiles/http-tests.yaml
@@ -229,7 +229,7 @@ config:
 #
 # Scenario design:
 # - All scenarios include expect blocks for response validation
-# - REPL scenarios use think time of 1 second
+# - Think times simulate human pacing between actions (1–3s for HTTP, 1s + replDelay for REPL)
 # - No continueOnError flags - tests fail fast for clearer debugging
 # - Traffic differentiation comes from environment-specific phases and SLAs
 #
@@ -269,6 +269,7 @@ scenarios:
           expect:
             - statusCode: 200
             - hasProperty: "id"
+      - think: 2
       - post:
           url: "/v1/auth/login"
           json:
@@ -279,6 +280,7 @@ scenarios:
           expect:
             - statusCode: 200
             - hasProperty: "token"
+      - think: 2
       - get:
           url: "/v1/auth/session"
           headers:
@@ -312,7 +314,7 @@ scenarios:
           url: "/v1/features"
           expect:
             - statusCode: 200
-      - think: 1
+      - think: 3
       - get:
           url: "/v1/features"
           expect:
@@ -391,7 +393,7 @@ scenarios:
           capture:
             - json: "$.token"
               as: "authToken"
-      - think: 1
+      - think: 3
       - put:
           url: "/v1/data"
           headers:

--- a/test/performance/profiles/http-tests.yaml
+++ b/test/performance/profiles/http-tests.yaml
@@ -54,7 +54,7 @@ config:
   #
   # Differences from other profiles:
   #   - Shortest duration (30s vs 12-15 min for load/stress)
-  #   - Lowest traffic (2-5 req/s vs up to 300 req/s for stress)
+  #   - Lowest traffic (2-5 req/s vs up to 60 req/s for stress)
   #   - Strictest SLAs (designed to pass reliably)
   # ==========================================================================
   environments:
@@ -81,10 +81,10 @@ config:
     # Use when: Establishing performance baselines, capacity planning, regression testing
     #
     # What it tests:
-    #   - All 9 API scenarios run with production-like traffic (5-30 req/s)
+    #   - All 9 API scenarios run with production-like traffic (2-12 req/s)
     #   - Sustained load over 12 minutes to establish performance baselines
     #   - Tests system stability under realistic user patterns
-    #   - Expected behavior: Maintains low latency (p99 < 2s, median < 500ms)
+    #   - Expected behavior: Maintains low latency (p99 < 2s, median < 750ms)
     #
     # Traffic pattern:
     #   - Warm up:      60s at 2 req/s
@@ -100,8 +100,8 @@ config:
     #
     # Differences from other profiles:
     #   - Medium duration (12 min vs 30s for smoke, 15 min for stress)
-    #   - Production-like traffic (5-30 req/s steady)
-    #   - Includes median latency SLA (< 500ms) for user experience validation
+    #   - Production-like traffic (2-12 req/s steady)
+    #   - Includes median latency SLA (< 750ms) for user experience validation
     #   - Multi-phase pattern: warm up → ramp → sustained → peak → cool down
     # ========================================================================
     load:
@@ -145,7 +145,7 @@ config:
     # Use when: Capacity planning, identifying bottlenecks, testing autoscaling triggers
     #
     # What it tests:
-    #   - All 9 API scenarios run with extreme traffic (10-300 req/s)
+    #   - All 9 API scenarios run with extreme traffic (3-60 req/s)
     #   - Pushes system beyond normal capacity to find breaking points
     #   - Identifies at what load level errors begin and latency degrades
     #   - Tests resource exhaustion: DB connections, memory, CPU limits
@@ -164,7 +164,7 @@ config:
     #
     # Differences from other profiles:
     #   - Longest duration (15 min) with aggressive ramp-up pattern
-    #   - Highest traffic volume (10-300 req/s)
+    #   - Highest traffic volume (3-60 req/s)
     #   - Relaxed SLAs (p99 < 10s, maxErrorRate < 10%) to allow finding limits
     #   - Purpose is to identify breaking points, not validate normal operation
     #

--- a/test/performance/profiles/http-tests.yaml
+++ b/test/performance/profiles/http-tests.yaml
@@ -87,15 +87,15 @@ config:
     #   - Expected behavior: Maintains low latency (p99 < 2s, median < 500ms)
     #
     # Traffic pattern:
-    #   - Warm up:      60s at 5 req/s
-    #   - Ramp up:      120s from 5 to 20 req/s
-    #   - Sustained:    300s at 20 req/s
-    #   - Peak:         180s at 30 req/s
-    #   - Cool down:    60s from 30 to 5 req/s
+    #   - Warm up:      60s at 2 req/s
+    #   - Ramp up:      120s from 2 to 8 req/s
+    #   - Sustained:    300s at 8 req/s
+    #   - Peak:         180s at 12 req/s
+    #   - Cool down:    60s from 12 to 2 req/s
     #
     # SLAs:
     #   - p99 response time < 2 seconds
-    #   - Median response time < 500ms
+    #   - Median response time < 750ms
     #   - Error rate < 1%
     #
     # Differences from other profiles:
@@ -108,29 +108,31 @@ config:
       phases:
         - name: "Warm up"
           duration: 60
-          arrivalRate: 5
+          arrivalRate: 2
         - name: "Ramp up"
           duration: 120
-          arrivalRate: 5
-          rampTo: 20
+          arrivalRate: 2
+          rampTo: 8
         - name: "Sustained load"
           duration: 300
-          arrivalRate: 20
+          arrivalRate: 8
         - name: "Peak load"
           duration: 180
-          arrivalRate: 30
+          arrivalRate: 12
         - name: "Cool down"
           duration: 60
-          arrivalRate: 30
-          rampTo: 5
+          arrivalRate: 12
+          rampTo: 2
 
       ensure:
         # p99 < 2s: 99th percentile must stay under 2 seconds even at peak load
         # This ensures outliers don't degrade user experience significantly
         p99: 2000
-        # median < 500ms: Typical response should feel snappy to users
-        # Half of all requests must complete within half a second
-        median: 500
+        # median < 750ms: t2.small's 20% CPU baseline (~0.2 vCPU) raises latency
+        # floor vs the t3.large this suite was originally written for (0.6 vCPU).
+        # 750ms is still comfortably user-perceptible as responsive and will flag
+        # genuine regressions without producing false failures on the slower instance.
+        median: 750
         # maxErrorRate < 1%: Production-like load should not cause errors
         # Errors under sustained load indicate capacity or stability issues
         maxErrorRate: 1
@@ -150,11 +152,11 @@ config:
     #   - Expected behavior: Graceful degradation, some errors acceptable
     #
     # Traffic pattern (aggressive ramp-up):
-    #   - Baseline:     60s at 10 req/s
-    #   - Moderate:     120s ramp to 50 req/s, hold 120s
-    #   - High:         120s ramp to 100 req/s, hold 120s
-    #   - Extreme:      120s ramp to 200 req/s, hold 120s
-    #   - Beyond:       60s ramp to 300 req/s
+    #   - Baseline:     60s at 3 req/s
+    #   - Moderate:     120s ramp to 15 req/s, hold 120s
+    #   - High:         120s ramp to 25 req/s, hold 120s
+    #   - Extreme:      120s ramp to 40 req/s, hold 120s
+    #   - Beyond:       60s ramp to 60 req/s
     #
     # SLAs (intentionally relaxed - we expect failures):
     #   - p99 response time < 10 seconds
@@ -171,42 +173,43 @@ config:
     #   - Point where latency degrades significantly
     #   - Memory/CPU usage on the server during test
     #
-    # t3.large notes:
-    #   - Results depend on CPU credit balance
-    #   - With credits: expect breaking at 200+ req/s
-    #   - After depletion: expect breaking at ~50-100 req/s
+    # t2.small notes:
+    #   - 1 vCPU with 20% baseline (~0.2 vCPU sustained)
+    #   - CPU credits: 12/hour (accumulate up to 288); no Unlimited mode by default
+    #   - With credits: expect breaking at ~30-40 req/s
+    #   - After depletion: expect breaking at ~15-25 req/s
     #   - For sustained baseline testing, run after credits are depleted
     # ========================================================================
     stress:
       phases:
         - name: "Baseline"
           duration: 60
-          arrivalRate: 10
+          arrivalRate: 3
         - name: "Ramp to moderate"
           duration: 120
-          arrivalRate: 10
-          rampTo: 50
+          arrivalRate: 3
+          rampTo: 15
         - name: "Hold moderate"
           duration: 120
-          arrivalRate: 50
+          arrivalRate: 15
         - name: "Ramp to high"
           duration: 120
-          arrivalRate: 50
-          rampTo: 100
+          arrivalRate: 15
+          rampTo: 25
         - name: "Hold high"
           duration: 120
-          arrivalRate: 100
+          arrivalRate: 25
         - name: "Ramp to extreme"
           duration: 120
-          arrivalRate: 100
-          rampTo: 200
+          arrivalRate: 25
+          rampTo: 40
         - name: "Hold extreme"
           duration: 120
-          arrivalRate: 200
+          arrivalRate: 40
         - name: "Beyond capacity"
           duration: 60
-          arrivalRate: 200
-          rampTo: 300
+          arrivalRate: 40
+          rampTo: 60
 
       ensure:
         # p99 < 10s: Allow high latency since we're pushing past normal limits

--- a/test/performance/profiles/http-tests.yaml
+++ b/test/performance/profiles/http-tests.yaml
@@ -13,7 +13,7 @@
 #   make test-perf-smoke
 #   make test-perf-load
 #
-# IMPORTANT: All 8 scenarios run in ALL environments (smoke/load).
+# IMPORTANT: All 7 scenarios run in ALL environments (smoke/load).
 # Environments differ ONLY in their phases (duration/traffic) and SLAs.
 # Scenario weights, think times, and request flows are identical across
 # all environments. This is a fundamental limitation of Artillery's
@@ -51,7 +51,7 @@ config:
   #   - Error rate < 1%
   #
   # Differences from load profile:
-  #   - Shortest duration (30s vs ~12 min for load)
+  #   - Shortest duration (30s vs ~14 min for load)
   #   - Lowest traffic (2-5 req/s vs up to 12 req/s for load)
   #   - Strictest SLAs (designed to pass reliably)
   # ==========================================================================
@@ -75,18 +75,18 @@ config:
     # ENVIRONMENT: LOAD TEST
     # ========================================================================
     # Purpose: Measure system performance under expected production-like traffic
-    # Duration: ~12 minutes
+    # Duration: ~14 minutes
     # Use when: Establishing performance baselines, capacity planning, regression testing
     #
     # What it tests:
-    #   - All 8 API scenarios run with production-like traffic (2-12 req/s)
-    #   - Sustained load over 12 minutes to establish performance baselines
+    #   - All 7 API scenarios run with production-like traffic (2-12 req/s)
+    #   - Sustained load over 14 minutes to establish performance baselines
     #   - Tests system stability under realistic user patterns
     #   - Expected behavior: Maintains low latency (p99 < 2s, median < 750ms)
     #
     # Traffic pattern:
     #   - Warm up:      60s at 2 req/s
-    #   - Ramp up:      120s from 2 to 8 req/s
+    #   - Ramp up:      240s from 2 to 8 req/s
     #   - Sustained:    300s at 8 req/s
     #   - Peak:         180s at 12 req/s
     #   - Cool down:    60s from 12 to 2 req/s
@@ -96,8 +96,8 @@ config:
     #   - Median response time < 750ms
     #   - Error rate < 1%
     #
-    # Differences from other profiles:
-    #   - Medium duration (12 min vs 30s for smoke, 15 min for stress)
+    # Differences from smoke profile:
+    #   - Longer duration (~14 min vs 30s for smoke)
     #   - Production-like traffic (2-12 req/s steady)
     #   - Includes median latency SLA (< 750ms) for user experience validation
     #   - Multi-phase pattern: warm up → ramp → sustained → peak → cool down
@@ -126,7 +126,7 @@ config:
         # p99 < 2s: 99th percentile must stay under 2 seconds even at peak load
         # This ensures outliers don't degrade user experience significantly
         p99: 2000
-        # median < 750ms: t2.small's 20% CPU baseline (~0.2 vCPU) raises latency
+        # median < 750ms: t3.small's 20% CPU baseline (~0.4 vCPU) raises latency
         # floor vs the t3.large this suite was originally written for (0.6 vCPU).
         # 750ms is still comfortably user-perceptible as responsive and will flag
         # genuine regressions without producing false failures on the slower instance.
@@ -139,7 +139,7 @@ config:
 # =============================================================================
 # SHARED SCENARIOS
 # =============================================================================
-# All scenarios below are shared across smoke/load environments.
+# All 7 scenarios below are shared across smoke/load environments.
 # Artillery's environments feature means ALL scenarios run in ALL environments,
 # with different phases and SLAs per environment controlling the test behavior.
 #

--- a/test/performance/profiles/http-tests.yaml
+++ b/test/performance/profiles/http-tests.yaml
@@ -110,7 +110,7 @@ config:
           duration: 60
           arrivalRate: 2
         - name: "Ramp up"
-          duration: 120
+          duration: 240
           arrivalRate: 2
           rampTo: 8
         - name: "Sustained load"
@@ -432,7 +432,7 @@ scenarios:
   # ===========================================================================
 
   - name: "REPL JavaScript execution"
-    weight: 2
+    weight: 1
     engine: ws
     flow:
       - function: "generateJsReplCode"
@@ -444,19 +444,4 @@ scenarios:
           payload:
             code: "{{ replCode }}"
             language: "javascript"
-      - think: "{{ replDelay }}"
-
-  - name: "REPL Python execution"
-    weight: 1
-    engine: ws
-    flow:
-      - function: "generatePyReplCode"
-      - connect: "{{ $processEnvironment.ARTILLERY_WS_TARGET }}"
-      - think: 1
-      # Dynamic Python code with variable execution time (1-40s, see processors/functions.js)
-      - send:
-          action: "repl"
-          payload:
-            code: "{{ replCode }}"
-            language: "python"
       - think: "{{ replDelay }}"

--- a/test/performance/profiles/repl-capacity.yaml
+++ b/test/performance/profiles/repl-capacity.yaml
@@ -118,8 +118,11 @@ scenarios:
       - send:
           action: "repl"
           payload:
-            # let sum = 0; for(let i = 0; i < 1000000; i++) { sum += i; } console.log(sum);
-            code: "bGV0IHN1bSA9IDA7IGZvcihsZXQgaSA9IDA7IGkgPCAxMDAwMDAwOyBpKyspIHsgc3VtICs9IGk7IH0gY29uc29sZS5sb2coc3VtKTs="
+            # const {G} = require('@savingsatoshi/secp256k1js');
+            # const key = BigInt('0xdeadbeef0123456789abcdef0123456789abcdef0123456789abcdef01234567');
+            # for (let i = 0n; i < 10n; i++) { G.mul(key + i); }
+            # console.log('Done');
+            code: "Y29uc3Qge0d9ID0gcmVxdWlyZSgnQHNhdmluZ3NhdG9zaGkvc2VjcDI1NmsxanMnKTsKY29uc3Qga2V5ID0gQmlnSW50KCcweGRlYWRiZWVmMDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWYwMTIzNDU2Nzg5YWJjZGVmMDEyMzQ1NjcnKTsKZm9yIChsZXQgaSA9IDBuOyBpIDwgMTBuOyBpKyspIHsgRy5tdWwoa2V5ICsgaSk7IH0KY29uc29sZS5sb2coJ0RvbmUnKTs="
             language: "javascript"
       - think: 10
 

--- a/test/performance/profiles/repl-capacity.yaml
+++ b/test/performance/profiles/repl-capacity.yaml
@@ -1,15 +1,22 @@
 # =============================================================================
 # REPL CAPACITY TEST - Container Limits
 # =============================================================================
-# Purpose: Determine sustained REPL capacity on t3.large
+# Purpose: Determine sustained REPL capacity on t2.small
 # Duration: ~12 minutes (longer phases to observe CPU credit depletion)
 # Use when: EC2 instance sizing, autoscaling configuration, resource planning
 #
-# t3.large specifics:
-#   - 2 vCPU with 30% baseline (~0.6 vCPU sustained)
-#   - 8 GB RAM (memory is not the bottleneck)
-#   - CPU credits deplete under sustained load
-#   - After depletion: performance drops to baseline
+# t2.small specifics:
+#   - 1 vCPU with 20% baseline (~0.2 vCPU sustained)
+#   - 2 GB RAM (memory IS the bottleneck alongside CPU)
+#   - CPU credits: 12/hour; no Unlimited mode by default
+#   - After depletion: performance drops hard to 0.2 vCPU baseline
+#
+# Memory budget:
+#   - Total:      2048 MB
+#   - OS:         ~400 MB
+#   - Node app:   ~300 MB
+#   - Available:  ~1350 MB
+#   - Per container: 256 MB → hard cap of ~5 containers before OOM
 #
 # What it tests:
 #   - WebSocket connections (not HTTP like other profiles)
@@ -20,11 +27,11 @@
 #   - Sustained performance (credits depleting)
 #
 # Traffic pattern (conservative for burstable):
-#   - Baseline:     60s with max 5 concurrent (warm up)
-#   - Light:        120s with max 8 concurrent (observe credit usage)
-#   - Moderate:     180s with max 12 concurrent (sustained load)
-#   - Sustained:    180s with max 15 concurrent (credit depletion)
-#   - Peak:         120s with max 20 concurrent (worst-case test)
+#   - Baseline:     60s with max 2 concurrent (warm up)
+#   - Light:        120s with max 3 concurrent (observe credit usage)
+#   - Moderate:     180s with max 4 concurrent (sustained load)
+#   - Sustained:    180s with max 5 concurrent (approaching OOM limit)
+#   - Peak:         120s with max 6 concurrent (beyond safe limit)
 #
 # Code executed:
 #   - JavaScript: Hello world, computation loops
@@ -41,35 +48,35 @@
 #   - Critical for AWS instance sizing decisions
 #   - Longer phases to observe CPU credit depletion
 #
-# Capacity estimates for t3.large (8GB RAM, 30% CPU baseline):
-#   - Burst:      ~25 concurrent containers (with credits)
-#   - Sustained:  ~10-15 concurrent containers (after credit depletion)
-#   - Critical:   >20 concurrent containers
+# Capacity estimates for t2.small (2GB RAM, 20% CPU baseline):
+#   - Burst:      ~3-4 concurrent containers (with credits)
+#   - Sustained:  ~2 concurrent containers (after credit depletion)
+#   - Critical:   >5 concurrent containers (memory exhaustion)
 # =============================================================================
 
 config:
   target: "ws://localhost:8001"
   phases:
-    - name: "Baseline - 5 concurrent (burst mode)"
+    - name: "Baseline - 2 concurrent (burst mode)"
       duration: 60
       arrivalRate: 1
-      maxVusers: 5
-    - name: "Light load - 8 concurrent (credits available)"
+      maxVusers: 2
+    - name: "Light load - 3 concurrent (credits available)"
       duration: 120
       arrivalRate: 1
-      maxVusers: 8
-    - name: "Moderate - 12 concurrent (credits depleting)"
+      maxVusers: 3
+    - name: "Moderate - 4 concurrent (credits depleting)"
       duration: 180
-      arrivalRate: 2
-      maxVusers: 12
-    - name: "Sustained - 15 concurrent (near baseline)"
+      arrivalRate: 1
+      maxVusers: 4
+    - name: "Sustained - 5 concurrent (approaching memory limit)"
       duration: 180
-      arrivalRate: 2
-      maxVusers: 15
-    - name: "Peak - 20 concurrent (baseline performance)"
+      arrivalRate: 1
+      maxVusers: 5
+    - name: "Peak - 6 concurrent (beyond safe limit)"
       duration: 120
-      arrivalRate: 2
-      maxVusers: 20
+      arrivalRate: 1
+      maxVusers: 6
 
   plugins:
     expect: {}

--- a/test/performance/profiles/repl-capacity.yaml
+++ b/test/performance/profiles/repl-capacity.yaml
@@ -1,0 +1,164 @@
+# =============================================================================
+# REPL CAPACITY TEST - Container Limits
+# =============================================================================
+# Purpose: Determine sustained REPL capacity on t3.large
+# Duration: ~12 minutes (longer phases to observe CPU credit depletion)
+# Use when: EC2 instance sizing, autoscaling configuration, resource planning
+#
+# t3.large specifics:
+#   - 2 vCPU with 30% baseline (~0.6 vCPU sustained)
+#   - 8 GB RAM (memory is not the bottleneck)
+#   - CPU credits deplete under sustained load
+#   - After depletion: performance drops to baseline
+#
+# What it tests:
+#   - WebSocket connections (not HTTP like other profiles)
+#   - Docker container spawn rate and limits
+#   - Memory consumption (each container uses 256MB)
+#   - Container execution timeout handling (30s limit)
+#   - Initial burst performance (with credits)
+#   - Sustained performance (credits depleting)
+#
+# Traffic pattern (conservative for burstable):
+#   - Baseline:     60s with max 5 concurrent (warm up)
+#   - Light:        120s with max 8 concurrent (observe credit usage)
+#   - Moderate:     180s with max 12 concurrent (sustained load)
+#   - Sustained:    180s with max 15 concurrent (credit depletion)
+#   - Peak:         120s with max 20 concurrent (worst-case test)
+#
+# Code executed:
+#   - JavaScript: Hello world, computation loops
+#   - Python: Hello world prints
+#   - Sequential executions (simulates user iterating)
+#
+# SLAs (adjusted for burstable performance):
+#   - p99 response time < 40 seconds (allow for CPU throttling)
+#   - Error rate < 10% (expect some failures under throttling)
+#
+# Differences from other profiles:
+#   - Uses WebSocket engine instead of HTTP
+#   - Tests container orchestration, not API endpoints
+#   - Critical for AWS instance sizing decisions
+#   - Longer phases to observe CPU credit depletion
+#
+# Capacity estimates for t3.large (8GB RAM, 30% CPU baseline):
+#   - Burst:      ~25 concurrent containers (with credits)
+#   - Sustained:  ~10-15 concurrent containers (after credit depletion)
+#   - Critical:   >20 concurrent containers
+# =============================================================================
+
+config:
+  target: "ws://localhost:8001"
+  phases:
+    - name: "Baseline - 5 concurrent (burst mode)"
+      duration: 60
+      arrivalRate: 1
+      maxVusers: 5
+    - name: "Light load - 8 concurrent (credits available)"
+      duration: 120
+      arrivalRate: 1
+      maxVusers: 8
+    - name: "Moderate - 12 concurrent (credits depleting)"
+      duration: 180
+      arrivalRate: 2
+      maxVusers: 12
+    - name: "Sustained - 15 concurrent (near baseline)"
+      duration: 180
+      arrivalRate: 2
+      maxVusers: 15
+    - name: "Peak - 20 concurrent (baseline performance)"
+      duration: 120
+      arrivalRate: 2
+      maxVusers: 20
+
+  plugins:
+    expect: {}
+    metrics-by-endpoint: {}
+
+  # SLA thresholds - adjusted for burstable t3 instances
+  ensure:
+    # p99 < 40s: Allow extra time for CPU throttling under sustained load
+    # Burstable instances may queue requests when throttled
+    p99: 40000
+    # maxErrorRate < 10%: Higher tolerance as throttling may cause timeouts
+    # Monitor actual error rate to find sustainable concurrency
+    maxErrorRate: 10
+
+  engines:
+    ws: {}
+
+scenarios:
+  - name: "JavaScript REPL - Hello World"
+    weight: 4
+    engine: ws
+    flow:
+      - connect: "ws://localhost:8001"
+      - think: 0.5
+      - send:
+          action: "repl"
+          payload:
+            # console.log("Hello from Artillery test");
+            code: "Y29uc29sZS5sb2coIkhlbGxvIGZyb20gQXJ0aWxsZXJ5IHRlc3QiKTs="
+            language: "javascript"
+      - think: 5
+
+  - name: "JavaScript REPL - Computation"
+    weight: 2
+    engine: ws
+    flow:
+      - connect: "ws://localhost:8001"
+      - think: 0.5
+      - send:
+          action: "repl"
+          payload:
+            # let sum = 0; for(let i = 0; i < 1000000; i++) { sum += i; } console.log(sum);
+            code: "bGV0IHN1bSA9IDA7IGZvcihsZXQgaSA9IDA7IGkgPCAxMDAwMDAwOyBpKyspIHsgc3VtICs9IGk7IH0gY29uc29sZS5sb2coc3VtKTs="
+            language: "javascript"
+      - think: 10
+
+  - name: "Python REPL - Hello World"
+    weight: 3
+    engine: ws
+    flow:
+      - connect: "ws://localhost:8001"
+      - think: 0.5
+      - send:
+          action: "repl"
+          payload:
+            # print("Hello from Python via Artillery")
+            code: "cHJpbnQoIkhlbGxvIGZyb20gUHl0aG9uIHZpYSBBcnRpbGxlcnkiKQ=="
+            language: "python"
+      - think: 5
+
+  - name: "Sequential REPL executions"
+    weight: 1
+    engine: ws
+    flow:
+      - connect: "ws://localhost:8001"
+      - think: 0.5
+      - loop:
+          - send:
+              action: "repl"
+              payload:
+                # console.log(Date.now());
+                code: "Y29uc29sZS5sb2coRGF0ZS5ub3coKSk7"
+                language: "javascript"
+          - think: 3
+        count: 3
+
+  - name: "JavaScript REPL - Timeout (30s+)"
+    # Low weight: timeout scenarios are edge cases but important to verify
+    # the system handles them gracefully without blocking other requests
+    weight: 1
+    engine: ws
+    flow:
+      - connect: "ws://localhost:8001"
+      - think: 0.5
+      - send:
+          action: "repl"
+          payload:
+            # while(true) {} - infinite loop that will trigger 30s timeout
+            code: "d2hpbGUodHJ1ZSkge30="
+            language: "javascript"
+      # Wait longer than timeout (30s) + cleanup overhead
+      - think: 35

--- a/test/performance/profiles/repl-capacity.yaml
+++ b/test/performance/profiles/repl-capacity.yaml
@@ -55,7 +55,7 @@
 # =============================================================================
 
 config:
-  target: "ws://localhost:8001"
+  target: "{{ $processEnvironment.ARTILLERY_WS_TARGET }}"
   phases:
     - name: "Baseline - 2 concurrent (burst mode)"
       duration: 60
@@ -99,7 +99,7 @@ scenarios:
     weight: 4
     engine: ws
     flow:
-      - connect: "ws://localhost:8001"
+      - connect: "{{ $processEnvironment.ARTILLERY_WS_TARGET }}"
       - think: 0.5
       - send:
           action: "repl"
@@ -113,7 +113,7 @@ scenarios:
     weight: 2
     engine: ws
     flow:
-      - connect: "ws://localhost:8001"
+      - connect: "{{ $processEnvironment.ARTILLERY_WS_TARGET }}"
       - think: 0.5
       - send:
           action: "repl"
@@ -130,7 +130,7 @@ scenarios:
     weight: 3
     engine: ws
     flow:
-      - connect: "ws://localhost:8001"
+      - connect: "{{ $processEnvironment.ARTILLERY_WS_TARGET }}"
       - think: 0.5
       - send:
           action: "repl"
@@ -144,7 +144,7 @@ scenarios:
     weight: 1
     engine: ws
     flow:
-      - connect: "ws://localhost:8001"
+      - connect: "{{ $processEnvironment.ARTILLERY_WS_TARGET }}"
       - think: 0.5
       - loop:
           - send:
@@ -162,7 +162,7 @@ scenarios:
     weight: 1
     engine: ws
     flow:
-      - connect: "ws://localhost:8001"
+      - connect: "{{ $processEnvironment.ARTILLERY_WS_TARGET }}"
       - think: 0.5
       - send:
           action: "repl"


### PR DESCRIPTION
This is an initial version of a small performance testing suite using [Artillery.io](https://www.artillery.io). It's currently tuned toward a `t3.small` instance (changed from production's `t2.small` as it has more CPU and is same cost) and features some general HTTP traffic simulation as well as a REPL capacity testing profile which performs actual cryptographic operations over a delayed wait time to simulate actual CPU pressure.

In practice, I've been using the `make test-perf-load` profile to run tests against the Autoscaling changes. The tests are probably waaay tooo aggressive in terms of representing actual user traffic, and it's possible the stress test could be removed. Currently, even the load test overwhelms the `t3.small` instance for about 2 minutes until fast-scaling emergency backups come online.

The test also highlights a number of other performance issues (on my test setup) that could be investigated, database activity or connection limits, for example.

Tests aren't perfect. They could be tuned to represent more realistic user traffic, with more accurate wait times (`think` actions), or traffic pattern that is more representative of actual users. It would be cool to increase the CloudWatch log retention setting during a class, or the next BOSS program, and have take a shot at creating test scenarios based on analysis of that traffic...

Either way, the current test fulfills the purpose of slamming the `staging` setup to provoke autoscaling to prove it works. Taking this out of WIP, at least.